### PR TITLE
ci(#3): README badges + CONTRIBUTING.md + branch protection policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+> 한성대 SW공학과 강의 실습 저장소. 학생이 PR을 보내며 SDLC 전 과정을 체험합니다.
+
+## 기본 규칙
+
+1. **Main 직접 push 금지** — 항상 feature 브랜치 + PR 흐름.
+2. **브랜치 네이밍** — `feature/issue-<N>-<kebab-slug>` (예: `feature/issue-11-us-01-search-slice`).
+3. **커밋 메시지** — [Conventional Commits](https://www.conventionalcommits.org) (`feat`, `fix`, `ci`, `docs`, `test`, `refactor`, `chore`). 본문 끝에 `Refs #N` 또는 `Closes #N`.
+4. **PR 본문** — 반드시 `Closes #<N>` 포함. 리뷰어 체크리스트는 템플릿을 사용.
+5. **머지 정책** — Squash merge, 머지 후 브랜치 삭제.
+
+## 머지 전 체크리스트 (PR 본문에 포함)
+
+- [ ] 이슈 본문의 **수락 기준(AC)** 을 모두 충족했는가?
+- [ ] 로컬 `pnpm --dir frontend lint test typecheck` / `cd backend && ruff check . && pytest` 통과?
+- [ ] `lint` · `test` 워크플로가 초록불인가?
+- [ ] 민감 정보(`.env`, API key) 가 포함되지 않았는가?
+- [ ] README / CLAUDE.md 업데이트가 필요하면 반영했는가?
+
+## Branch Protection (main)
+
+본 저장소의 `main` 브랜치는 다음 규칙으로 보호됩니다:
+
+- Pull request 경유 머지만 허용 (직접 push 금지)
+- 필수 상태 체크: `Frontend · Biome`, `Backend · Ruff`, `Frontend · Vitest + typecheck`, `Backend · pytest` — 모두 초록불이어야 머지 가능
+- Stale 리뷰 자동 해제 (브랜치에 새 커밋이 들어오면 기존 승인 무효화)
+- 관리자(교수) 는 비상시 우회 가능 (`enforce_admins: false`)
+
+## 로컬 개발 셋업
+
+```bash
+git clone https://github.com/ischung/techreport-from-utube.git
+cd techreport-from-utube
+cp .env.example .env
+pnpm --dir frontend install
+uv --directory backend sync --extra dev
+```
+
+상세한 실행 방법은 [README.md](./README.md) 를 참조하세요.
+
+## Pre-commit 설치 (선택, 강력 권장)
+
+```bash
+pipx install pre-commit
+pre-commit install
+pre-commit run --all-files     # 최초 검증
+```
+
+매 커밋마다 `ruff` (backend), `biome` (frontend), 파일 위생 hook 이 자동 실행됩니다.
+
+## 질문
+
+- Issue: https://github.com/ischung/techreport-from-utube/issues
+- Email: insang@hansung.ac.kr

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TechReport from YouTube
 
+[![lint](https://github.com/ischung/techreport-from-utube/actions/workflows/lint.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/lint.yml)
+[![test](https://github.com/ischung/techreport-from-utube/actions/workflows/test.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/test.yml)
+
 키워드 한 줄로 최근 1개월 YouTube 영상 5개를 찾아, 선택한 1편을 분석해 **한국어 기술보고서(마크다운)** 를 자동 생성하는 로컬 웹 대시보드입니다. 한성대 소프트웨어공학과 강의 데모 및 SDLC 실습 교재로 사용됩니다.
 
 ## 3분만에 시작하기


### PR DESCRIPTION
Closes #3

## 변경 사항
- `README.md` 최상단에 lint/test 상태 배지 추가
- `CONTRIBUTING.md` 신설: 브랜치/커밋 규칙, PR 체크리스트, Branch protection 정책, 로컬 셋업 + pre-commit 가이드

## Branch Protection 설정
머지 후 본 PR과 별도로 `gh api` 로 main 브랜치 보호를 활성화합니다:
- 필수 status checks: `Frontend · Biome`, `Backend · Ruff`, `Frontend · Vitest + typecheck`, `Backend · pytest`
- PR review: 0 (본인 혼자 작업 환경. 조별 과제 시 1로 상향 가능)
- stale review dismissal: on
- enforce_admins: false (비상 우회)

## 인수 기준
- [x] PR 생성 시 lint/test 자동 실행
- [x] 두 워크플로 초록불 필수 (보호 규칙 설정 후 자동 강제)
- [x] 머지 후 branch protection API 호출로 정책 활성화

---
🤖 Generated by \`implement-top-issue\`