### PR TITLE
feat(#7): walking skeleton — /api/health + AppShell dashboard

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+
+from app import __version__
+from app.config import Settings, get_settings
+from app.schemas import HealthData, HealthResponse
+
+router = APIRouter(prefix="/api", tags=["health"])
+
+
+@router.get("/health", response_model=HealthResponse)
+def health(settings: Settings = Depends(get_settings)) -> HealthResponse:
+    """Return a minimal status envelope so the frontend dashboard can
+    prove end-to-end connectivity without invoking any external API."""
+    return HealthResponse(
+        ok=True,
+        data=HealthData(
+            status="up",
+            llmProvider=settings.llm_provider,
+            version=__version__,
+        ),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
+from app.api.health import router as health_router
 
 
 def create_app() -> FastAPI:
@@ -22,6 +23,8 @@ def create_app() -> FastAPI:
     @app.get("/")
     def root() -> dict[str, str]:
         return {"service": "techreport-backend", "version": __version__}
+
+    app.include_router(health_router)
 
     return app
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,25 @@
+"""Shared Pydantic DTOs — mirror of shared/types.ts on the frontend side.
+
+Kept deliberately flat. Each enlargement should be motivated by a TechSpec
+section number so the mirror stays in sync.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class HealthData(BaseModel):
+    """Data payload for /api/health — TechSpec §5-3."""
+
+    status: Literal["up", "degraded", "down"] = "up"
+    llm_provider: str = Field(..., alias="llmProvider")
+    version: str
+
+    model_config = {"populate_by_name": True}
+
+
+class HealthResponse(BaseModel):
+    ok: bool = True
+    data: HealthData

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,6 +3,7 @@
 Kept deliberately flat. Each enlargement should be motivated by a TechSpec
 section number so the mirror stays in sync.
 """
+
 from __future__ import annotations
 
 from typing import Literal

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,7 +38,9 @@ extend-exclude = [".venv", "dist", "build"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "SIM", "PT"]
-ignore = ["E501"]
+# E501: long-line noise handled by formatter; B008: FastAPI `Depends()` default
+#   argument is the idiomatic pattern and shouldn't be flagged.
+ignore = ["E501", "B008"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_health_endpoint_returns_expected_envelope() -> None:
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["status"] == "up"
+    assert "llmProvider" in data
+    assert "version" in data
+    assert isinstance(data["llmProvider"], str)
+    assert isinstance(data["version"], str)
+
+
+def test_health_response_time_is_fast() -> None:
+    import time
+
+    client = TestClient(app)
+    start = time.perf_counter()
+    response = client.get("/api/health")
+    elapsed = time.perf_counter() - start
+    assert response.status_code == 200
+    assert elapsed < 3.0, f"/api/health took {elapsed:.3f}s (expected <3s)"

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
     "rules": {
       "recommended": true,
       "style": {
-        "noNonNullAssertion": "warn"
+        "noNonNullAssertion": "off"
       }
     }
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,27 @@
+import { AppShell } from "@/components/AppShell";
+
 export default function App() {
   return (
-    <main className="min-h-screen bg-bg text-fg font-sans flex items-center justify-center">
-      <div className="max-w-xl text-center px-6">
-        <h1 className="text-3xl font-semibold mb-3">TechReport from YouTube</h1>
-        <p className="text-fg-muted mb-6">
-          Monorepo scaffolding complete. The dashboard UI (CI-7 Walking Skeleton) will render here
-          once{" "}
-          <code className="font-mono text-sm bg-bg-card px-1.5 py-0.5 rounded">/api/health</code> is
-          implemented.
+    <AppShell>
+      <section className="space-y-4">
+        <h2 className="text-lg font-medium">Hello Dashboard</h2>
+        <p className="max-w-2xl text-sm text-fg-muted">
+          Phase 0-C Walking Skeleton. 사이드바 하단의 상태 도트가{" "}
+          <span className="font-mono text-accent">emerald</span> 이면 백엔드{" "}
+          <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-xs">/api/health</code> 가
+          응답하고 있다는 뜻입니다. 이후 Phase 1 (#11, #12, #13) 에서 키워드 입력 → 영상 리스트 →
+          분석 보고서 흐름이 이 자리에 렌더링됩니다.
         </p>
-        <p className="text-xs font-mono text-fg-subtle">
-          feature/issue-1-monorepo-scaffolding · v0.1.0-pre
-        </p>
-      </div>
-    </main>
+
+        <dl className="grid max-w-md grid-cols-[auto_1fr] gap-x-6 gap-y-2 rounded-lg border border-border bg-bg-card p-5 text-sm">
+          <dt className="text-fg-muted">Phase</dt>
+          <dd className="font-mono">0-C · Walking Skeleton</dd>
+          <dt className="text-fg-muted">Issue</dt>
+          <dd className="font-mono">#7 (CI-7)</dd>
+          <dt className="text-fg-muted">Backend</dt>
+          <dd className="font-mono text-accent">/api/health → 200</dd>
+        </dl>
+      </section>
+    </AppShell>
   );
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,21 @@
+import { DashboardHeader } from "@/components/DashboardHeader";
+import { Sidebar } from "@/components/Sidebar";
+
+interface AppShellProps {
+  children?: React.ReactNode;
+}
+
+export function AppShell({ children }: AppShellProps) {
+  return (
+    <div className="flex min-h-screen bg-bg text-fg">
+      <Sidebar />
+      <main className="flex flex-1 flex-col" aria-label="Main content">
+        <DashboardHeader
+          title="TechReport from YouTube"
+          subtitle="Walking Skeleton — /api/health 가 녹색이어야 기능 슬라이스가 시작됩니다."
+        />
+        <div className="flex-1 overflow-auto px-8 py-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/BrandMark.tsx
+++ b/frontend/src/components/BrandMark.tsx
@@ -1,0 +1,15 @@
+import { Youtube } from "lucide-react";
+
+export function BrandMark() {
+  return (
+    <div className="flex items-center gap-2 px-4 py-4 border-b border-border">
+      <span className="grid h-8 w-8 place-items-center rounded-md bg-error/10 text-error">
+        <Youtube size={18} strokeWidth={2.25} aria-hidden="true" />
+      </span>
+      <div className="flex flex-col leading-tight">
+        <span className="font-semibold text-sm text-fg">TechReport</span>
+        <span className="font-mono text-[10px] text-fg-subtle">from YouTube</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DashboardHeader.tsx
+++ b/frontend/src/components/DashboardHeader.tsx
@@ -1,0 +1,18 @@
+interface DashboardHeaderProps {
+  title: string;
+  subtitle?: string;
+}
+
+export function DashboardHeader({ title, subtitle }: DashboardHeaderProps) {
+  return (
+    <header className="flex items-baseline justify-between border-b border-border bg-bg-subtle px-8 py-5">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {subtitle ? <p className="mt-1 text-sm text-fg-muted">{subtitle}</p> : null}
+      </div>
+      <span className="font-mono text-[11px] text-fg-subtle">
+        {new Date().toISOString().slice(0, 10)}
+      </span>
+    </header>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,65 @@
+import { BrandMark } from "@/components/BrandMark";
+import { StatusDot } from "@/components/StatusDot";
+import { useHealth } from "@/hooks/useHealth";
+import { FileText, Home, Settings } from "lucide-react";
+
+interface NavItem {
+  label: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number; "aria-hidden"?: boolean }>;
+  active: boolean;
+  disabled?: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { label: "Dashboard", icon: Home, active: true },
+  { label: "History", icon: FileText, active: false, disabled: true },
+  { label: "Settings", icon: Settings, active: false, disabled: true },
+];
+
+export function Sidebar() {
+  const { status, data } = useHealth();
+
+  return (
+    <aside
+      className="flex h-screen w-60 flex-col border-r border-border bg-bg-subtle"
+      aria-label="Primary navigation"
+    >
+      <BrandMark />
+
+      <nav className="flex-1 px-3 py-4">
+        <ul className="space-y-1">
+          {NAV_ITEMS.map((item) => (
+            <li key={item.label}>
+              <button
+                type="button"
+                disabled={item.disabled}
+                aria-current={item.active ? "page" : undefined}
+                className={
+                  item.active
+                    ? "flex w-full items-center gap-2 rounded-md bg-bg-card px-3 py-2 text-sm text-fg shadow-card"
+                    : "flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-fg-muted hover:bg-bg-card hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+                }
+              >
+                <item.icon size={16} strokeWidth={2} aria-hidden />
+                <span>{item.label}</span>
+                {item.disabled ? (
+                  <span className="ml-auto font-mono text-[10px] text-fg-subtle">soon</span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <footer className="border-t border-border px-4 py-3 text-xs text-fg-muted">
+        <div className="flex items-center justify-between">
+          <StatusDot status={status} />
+          <span className="font-mono text-fg-subtle">v{data?.version ?? "0.0.0"}</span>
+        </div>
+        {data ? (
+          <p className="mt-1 font-mono text-[10px] text-fg-subtle">llm: {data.llmProvider}</p>
+        ) : null}
+      </footer>
+    </aside>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 import { BrandMark } from "@/components/BrandMark";
 import { StatusDot } from "@/components/StatusDot";
 import { useHealth } from "@/hooks/useHealth";
-import { FileText, Home, Settings } from "lucide-react";
+import { FileText, Home, type LucideIcon, Settings } from "lucide-react";
 
 interface NavItem {
   label: string;
-  icon: React.ComponentType<{ size?: number; strokeWidth?: number; "aria-hidden"?: boolean }>;
+  icon: LucideIcon;
   active: boolean;
   disabled?: boolean;
 }

--- a/frontend/src/components/StatusDot.tsx
+++ b/frontend/src/components/StatusDot.tsx
@@ -25,15 +25,14 @@ const LABEL_MAP: Record<HealthStatus, string> = {
 
 export function StatusDot({ status, label, className }: StatusDotProps) {
   return (
-    <span
+    <output
       className={cn("inline-flex items-center gap-2 text-xs font-mono", className)}
-      role="status"
       aria-live="polite"
       data-testid="status-dot"
       data-status={status}
     >
       <span aria-hidden="true" className={cn("h-2 w-2 rounded-full", COLOR_MAP[status])} />
       <span className="text-fg-muted">{label ?? LABEL_MAP[status]}</span>
-    </span>
+    </output>
   );
 }

--- a/frontend/src/components/StatusDot.tsx
+++ b/frontend/src/components/StatusDot.tsx
@@ -1,0 +1,39 @@
+import type { HealthStatus } from "@/hooks/useHealth";
+import { cn } from "@/lib/utils";
+
+interface StatusDotProps {
+  status: HealthStatus;
+  label?: string;
+  className?: string;
+}
+
+const COLOR_MAP: Record<HealthStatus, string> = {
+  up: "bg-accent",
+  degraded: "bg-warn",
+  down: "bg-error",
+  error: "bg-error",
+  loading: "bg-fg-subtle animate-pulse",
+};
+
+const LABEL_MAP: Record<HealthStatus, string> = {
+  up: "Online",
+  degraded: "Degraded",
+  down: "Offline",
+  error: "Error",
+  loading: "Checking…",
+};
+
+export function StatusDot({ status, label, className }: StatusDotProps) {
+  return (
+    <span
+      className={cn("inline-flex items-center gap-2 text-xs font-mono", className)}
+      role="status"
+      aria-live="polite"
+      data-testid="status-dot"
+      data-status={status}
+    >
+      <span aria-hidden="true" className={cn("h-2 w-2 rounded-full", COLOR_MAP[status])} />
+      <span className="text-fg-muted">{label ?? LABEL_MAP[status]}</span>
+    </span>
+  );
+}

--- a/frontend/src/hooks/useHealth.ts
+++ b/frontend/src/hooks/useHealth.ts
@@ -1,0 +1,39 @@
+import { type HealthData, fetchHealth } from "@/lib/api";
+import { useEffect, useState } from "react";
+
+export type HealthStatus = "up" | "degraded" | "down" | "loading" | "error";
+
+export interface UseHealthResult {
+  status: HealthStatus;
+  data: HealthData | null;
+  error: string | null;
+}
+
+export function useHealth(): UseHealthResult {
+  const [status, setStatus] = useState<HealthStatus>("loading");
+  const [data, setData] = useState<HealthData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchHealth()
+      .then((payload) => {
+        if (cancelled) return;
+        setData(payload);
+        setStatus(payload.status);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setStatus("error");
+        setError(err instanceof Error ? err.message : "unknown error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { status, data, error };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+export interface HealthData {
+  status: "up" | "degraded" | "down";
+  llmProvider: string;
+  version: string;
+}
+
+export interface HealthResponse {
+  ok: boolean;
+  data: HealthData;
+}
+
+const client = axios.create({
+  baseURL: "/api",
+  timeout: 3000,
+});
+
+export async function fetchHealth(): Promise<HealthData> {
+  const response = await client.get<HealthResponse>("/health");
+  return response.data.data;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import clsx, { type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,15 +1,21 @@
 import App from "@/App";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-describe("App", () => {
-  it("renders brand title", () => {
+describe("App / AppShell", () => {
+  it("renders the brand title and header", () => {
     render(<App />);
-    expect(screen.getByText("TechReport from YouTube")).toBeInTheDocument();
+    expect(screen.getAllByText(/TechReport/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Hello Dashboard")).toBeInTheDocument();
   });
 
-  it("shows scaffolding status hint", () => {
+  it("shows the health status dot eventually turning to Online", async () => {
     render(<App />);
-    expect(screen.getByText(/Monorepo scaffolding complete/i)).toBeInTheDocument();
+    const dot = screen.getByTestId("status-dot");
+    expect(dot).toBeInTheDocument();
+    await waitFor(() => {
+      expect(dot.getAttribute("data-status")).toBe("up");
+    });
+    expect(screen.getByText("Online")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,1 +1,15 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// Default axios mock — individual tests override via vi.mocked / vi.doMock
+vi.mock("axios", () => {
+  return {
+    default: {
+      create: () => ({
+        get: vi.fn().mockResolvedValue({
+          data: { ok: true, data: { status: "up", llmProvider: "claude", version: "0.1.0" } },
+        }),
+      }),
+    },
+  };
+});


### PR DESCRIPTION
Closes #7

Phase 0-C Walking Skeleton 핵심: 백엔드 `/api/health` + React 다크 대시보드 AppShell이 서로를 가리켜 E2E 관통 확인.

### Backend
- `app/schemas.py`, `app/api/health.py`, `tests/test_health.py`

### Frontend
- `src/components/{AppShell,Sidebar,BrandMark,StatusDot,DashboardHeader}.tsx`
- `src/hooks/useHealth.ts` + `src/lib/api.ts`
- `tests/App.test.tsx` — 'Online' 상태 도트 확인

이후 Phase 1 슬라이스(#11·#12·#13)는 이 AppShell 내 `<section>` 자리에 Wizard 5단계를 차례로 채웁니다.