### PR TITLE
test(#9): Playwright smoke — compose stack + dashboard/health

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,88 @@
+# E2E workflow — issue #9 (CI-9)
+#
+# Brings up the docker-compose stack then runs Playwright against it.
+# Expanded scenarios (no-transcript / no-results / success) come in #16.
+
+name: e2e
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: Playwright smoke (compose stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare .env for compose
+        run: cp .env.example .env
+
+      - name: Build images
+        run: docker compose build
+
+      - name: Bring stack up
+        run: docker compose up -d
+
+      - name: Wait for stack (smoke script)
+        run: ./scripts/smoke.sh
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost
+        run: pnpm test:e2e
+
+      - name: Collect compose logs on failure
+        if: failure()
+        run: |
+          mkdir -p compose-logs
+          docker compose logs --no-color > compose-logs/all.log || true
+
+      - name: Upload compose logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-compose-logs-${{ github.run_id }}
+          path: compose-logs/
+          retention-days: 7
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v || true

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E config — issue #9 (CI-9).
+ *
+ * The test points at whatever URL `PLAYWRIGHT_BASE_URL` resolves to,
+ * defaulting to the docker-compose frontend (http://localhost:80). The
+ * GH Actions job in `.github/workflows/e2e.yml` brings the compose stack
+ * up before invoking Playwright.
+ *
+ * Locally you can either
+ *   (a) `docker compose up -d && pnpm --dir frontend test:e2e`
+ *   (b) `pnpm --dir frontend dev` + point PLAYWRIGHT_BASE_URL at :5173
+ */
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Walking Skeleton smoke", () => {
+  test("dashboard loads and status dot turns online", async ({ page }) => {
+    await page.goto("/");
+
+    // Brand is visible — proves the SPA mounted
+    await expect(page.getByText("TechReport").first()).toBeVisible();
+
+    // The status dot eventually reports the backend as up ("Online")
+    const dot = page.getByTestId("status-dot");
+    await expect(dot).toBeVisible();
+    await expect(dot).toHaveAttribute("data-status", "up", { timeout: 10_000 });
+    await expect(dot).toContainText("Online");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,5 +23,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"],
+    // Keep Vitest focused on unit tests; Playwright owns tests/e2e/**
+    include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", "tests/e2e/**", "dist"],
   },
 });


### PR DESCRIPTION
Closes #9

Phase 0-C Walking Skeleton 마지막 퍼즐: 실제 브라우저 + compose stack E2E 1건.

- `playwright.config.ts` (chromium, baseURL env)
- `tests/e2e/smoke.spec.ts` — TechReport 브랜드 + status-dot → 'up'
- `.github/workflows/e2e.yml` — compose build/up + smoke.sh + playwright run + 아티팩트 수집
- `vite.config.ts` — Vitest include 한정(e2e 제외)