### PR TITLE
feat(#11): US-01 slice — keyword → 5 YouTube videos

### DIFF
--- a/backend/app/adapters/youtube_data_adapter.py
+++ b/backend/app/adapters/youtube_data_adapter.py
@@ -1,0 +1,58 @@
+"""Adapter over YouTube Data API v3 (search.list).
+
+Uses ``httpx`` directly rather than ``google-api-python-client`` so that
+requests are easy to mock in tests via ``respx``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+from app.ports.youtube_search_port import YouTubeSearchPort
+from app.schemas import VideoSearchResult
+
+
+class YouTubeDataAdapter(YouTubeSearchPort):
+    BASE_URL = "https://www.googleapis.com/youtube/v3/search"
+
+    def __init__(self, api_key: str, *, timeout: float = 5.0) -> None:
+        self._api_key = api_key
+        self._timeout = timeout
+
+    @staticmethod
+    def _published_after(now: datetime | None = None) -> str:
+        """Return an RFC3339 timestamp 30 days before ``now`` (UTC)."""
+        ref = now or datetime.now(tz=UTC)
+        return (ref - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    async def search_recent(self, keyword: str, *, max_results: int = 5) -> list[VideoSearchResult]:
+        params = {
+            "key": self._api_key,
+            "q": keyword,
+            "part": "snippet",
+            "type": "video",
+            "order": "date",
+            "maxResults": max_results,
+            "publishedAfter": self._published_after(),
+        }
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(self.BASE_URL, params=params)
+            response.raise_for_status()
+            payload = response.json()
+
+        results: list[VideoSearchResult] = []
+        for item in payload.get("items", [])[:max_results]:
+            vid = item["id"]["videoId"]
+            snippet = item["snippet"]
+            results.append(
+                VideoSearchResult(
+                    videoId=vid,
+                    title=snippet["title"],
+                    url=f"https://www.youtube.com/watch?v={vid}",
+                    publishedAt=snippet["publishedAt"],
+                    channelTitle=snippet["channelTitle"],
+                )
+            )
+        return results

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.deps import get_search_service
+from app.schemas import ApiError, SearchData, SearchRequest, SearchResponse
+from app.services.search_service import SearchService
+
+router = APIRouter(prefix="/api", tags=["search"])
+
+
+@router.post("/search", response_model=SearchResponse)
+async def search(
+    body: SearchRequest,
+    service: SearchService = Depends(get_search_service),
+) -> SearchResponse:
+    try:
+        videos = await service.search(body.keyword)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=ApiError(
+                code="YOUTUBE_API_ERROR",
+                message=f"YouTube API returned {exc.response.status_code}.",
+                retryable=True,
+            ).model_dump(),
+        ) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=ApiError(
+                code="YOUTUBE_API_ERROR",
+                message="YouTube API unreachable.",
+                retryable=True,
+            ).model_dump(),
+        ) from exc
+
+    if not videos:
+        raise HTTPException(
+            status_code=404,
+            detail=ApiError(
+                code="NO_RESULTS",
+                message="최근 1개월 이내 관련 영상을 찾지 못했어요.",
+                retryable=False,
+            ).model_dump(),
+        )
+
+    return SearchResponse(ok=True, data=SearchData(videos=videos))

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -6,13 +6,18 @@ Keeping these in a separate module makes overriding trivial in tests
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from fastapi import Depends
 
 from app.adapters.claude_adapter import ClaudeAdapter
 from app.adapters.ollama_adapter import OllamaAdapter
 from app.adapters.openai_adapter import OpenAIAdapter
+from app.adapters.youtube_data_adapter import YouTubeDataAdapter
 from app.config import Settings, get_settings
 from app.ports.llm_provider import LLMProvider
+from app.ports.youtube_search_port import YouTubeSearchPort
+from app.services.search_service import SearchService
 
 
 def get_llm_provider(settings: Settings = Depends(get_settings)) -> LLMProvider:
@@ -32,3 +37,18 @@ def get_llm_provider(settings: Settings = Depends(get_settings)) -> LLMProvider:
             raise ValueError(
                 f"Unknown LLM_PROVIDER: {unknown!r}. Valid values: claude | openai | ollama"
             )
+
+
+def get_youtube_search_port(settings: Settings = Depends(get_settings)) -> YouTubeSearchPort:
+    return YouTubeDataAdapter(api_key=settings.youtube_api_key)
+
+
+@lru_cache(maxsize=1)
+def _cached_service_factory(api_key: str) -> SearchService:
+    """Single SearchService per process so the in-memory cache is shared
+    across requests. Keyed by api_key to keep tests isolated."""
+    return SearchService(YouTubeDataAdapter(api_key=api_key))
+
+
+def get_search_service(settings: Settings = Depends(get_settings)) -> SearchService:
+    return _cached_service_factory(settings.youtube_api_key)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
 from app.api.health import router as health_router
+from app.api.search import router as search_router
 
 
 def create_app() -> FastAPI:
@@ -25,6 +26,7 @@ def create_app() -> FastAPI:
         return {"service": "techreport-backend", "version": __version__}
 
     app.include_router(health_router)
+    app.include_router(search_router)
 
     return app
 

--- a/backend/app/ports/youtube_search_port.py
+++ b/backend/app/ports/youtube_search_port.py
@@ -1,0 +1,18 @@
+"""YouTube search port — the pipeline's only contract for retrieval."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from app.schemas import VideoSearchResult
+
+
+class YouTubeSearchPort(ABC):
+    """Given a keyword, return up to 5 recent videos (last 30 days)."""
+
+    @abstractmethod
+    async def search_recent(self, keyword: str, *, max_results: int = 5) -> list[VideoSearchResult]:
+        """Return at most ``max_results`` videos published within the last month.
+
+        Ordering: most-recent upload first.
+        """

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -24,3 +24,39 @@ class HealthData(BaseModel):
 class HealthResponse(BaseModel):
     ok: bool = True
     data: HealthData
+
+
+class VideoSearchResult(BaseModel):
+    """Video metadata returned by /api/search — TechSpec §4-1."""
+
+    video_id: str = Field(..., alias="videoId")
+    title: str
+    url: str
+    published_at: str = Field(..., alias="publishedAt")
+    channel_title: str = Field(..., alias="channelTitle")
+
+    model_config = {"populate_by_name": True}
+
+
+class SearchRequest(BaseModel):
+    keyword: str = Field(..., min_length=2, max_length=100)
+
+
+class SearchData(BaseModel):
+    videos: list[VideoSearchResult]
+
+
+class SearchResponse(BaseModel):
+    ok: bool = True
+    data: SearchData
+
+
+class ApiError(BaseModel):
+    code: str
+    message: str
+    retryable: bool = False
+
+
+class ApiErrorResponse(BaseModel):
+    ok: bool = False
+    error: ApiError

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1,0 +1,56 @@
+"""Search orchestration + in-memory LRU cache.
+
+Keeps the YouTube API budget low by caching the most-recent queries for five
+minutes. A plain dict protected by ``asyncio.Lock`` is enough at this scale;
+we can swap in ``cachetools.TTLCache`` later if contention becomes a thing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+
+from app.ports.youtube_search_port import YouTubeSearchPort
+from app.schemas import VideoSearchResult
+
+_DEFAULT_TTL_SECONDS = 300.0
+_DEFAULT_CAPACITY = 64
+
+
+class SearchService:
+    def __init__(
+        self,
+        port: YouTubeSearchPort,
+        *,
+        ttl_seconds: float = _DEFAULT_TTL_SECONDS,
+        capacity: int = _DEFAULT_CAPACITY,
+    ) -> None:
+        self._port = port
+        self._ttl = ttl_seconds
+        self._capacity = capacity
+        self._cache: OrderedDict[str, tuple[float, list[VideoSearchResult]]] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def search(self, keyword: str) -> list[VideoSearchResult]:
+        key = keyword.strip().lower()
+        now = time.monotonic()
+
+        async with self._lock:
+            entry = self._cache.get(key)
+            if entry is not None:
+                expires_at, cached = entry
+                if expires_at > now:
+                    self._cache.move_to_end(key)
+                    return cached
+                del self._cache[key]
+
+        results = await self._port.search_recent(keyword)
+
+        async with self._lock:
+            self._cache[key] = (now + self._ttl, results)
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._capacity:
+                self._cache.popitem(last=False)
+
+        return results

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 dev = [
     "pytest>=8.2.0",
     "pytest-asyncio>=0.23.0",
+    "anyio>=4.3.0",
     "respx>=0.21.0",
     "ruff>=0.5.0",
 ]

--- a/backend/tests/test_search_route.py
+++ b/backend/tests/test_search_route.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.deps import get_search_service
+from app.main import app
+from app.schemas import VideoSearchResult
+
+
+class FakeService:
+    def __init__(self, videos: list[VideoSearchResult] | None = None) -> None:
+        self._videos = videos or []
+
+    async def search(self, keyword: str) -> list[VideoSearchResult]:  # noqa: ARG002
+        return self._videos
+
+
+@pytest.fixture(autouse=True)
+def reset_overrides() -> None:
+    app.dependency_overrides.pop(get_search_service, None)
+    yield
+    app.dependency_overrides.pop(get_search_service, None)
+
+
+def _sample_video(i: int = 0) -> VideoSearchResult:
+    return VideoSearchResult(
+        videoId=f"vid{i}",
+        title=f"Video {i}",
+        url=f"https://www.youtube.com/watch?v=vid{i}",
+        publishedAt="2026-04-15T10:00:00Z",
+        channelTitle=f"Channel {i}",
+    )
+
+
+def _override_with(fake: FakeService) -> None:
+    app.dependency_overrides[get_search_service] = lambda: fake
+
+
+def test_search_returns_envelope() -> None:
+    _override_with(FakeService([_sample_video(i) for i in range(5)]))
+    client = TestClient(app)
+    response = client.post("/api/search", json={"keyword": "react"})
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert body["ok"] is True
+    assert len(body["data"]["videos"]) == 5
+    first = body["data"]["videos"][0]
+    assert first["videoId"] == "vid0"
+    assert "publishedAt" in first
+
+
+def test_keyword_too_short_returns_422() -> None:
+    client = TestClient(app)
+    response = client.post("/api/search", json={"keyword": "x"})
+    assert response.status_code == 422
+
+
+def test_empty_result_returns_404_with_no_results_code() -> None:
+    _override_with(FakeService([]))
+    client = TestClient(app)
+    response = client.post("/api/search", json={"keyword": "zzzxxxyyy"})
+    assert response.status_code == 404
+    body = response.json()
+    assert body["detail"]["code"] == "NO_RESULTS"

--- a/backend/tests/test_youtube_adapter.py
+++ b/backend/tests/test_youtube_adapter.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+import respx
+
+from app.adapters.youtube_data_adapter import YouTubeDataAdapter
+
+
+def _mock_payload(n: int) -> dict[str, object]:
+    return {
+        "items": [
+            {
+                "id": {"videoId": f"vid{i}"},
+                "snippet": {
+                    "title": f"Video {i}",
+                    "channelTitle": f"Channel {i}",
+                    "publishedAt": "2026-04-15T10:00:00Z",
+                },
+            }
+            for i in range(n)
+        ]
+    }
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_search_parses_happy_response() -> None:
+    respx.get("https://www.googleapis.com/youtube/v3/search").mock(
+        return_value=httpx.Response(200, json=_mock_payload(5))
+    )
+    adapter = YouTubeDataAdapter(api_key="dummy")
+    results = await adapter.search_recent("react")
+    assert len(results) == 5
+    assert results[0].video_id == "vid0"
+    assert results[0].url == "https://www.youtube.com/watch?v=vid0"
+    assert results[0].channel_title == "Channel 0"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_search_caps_at_max_results() -> None:
+    respx.get("https://www.googleapis.com/youtube/v3/search").mock(
+        return_value=httpx.Response(200, json=_mock_payload(20))
+    )
+    adapter = YouTubeDataAdapter(api_key="dummy")
+    results = await adapter.search_recent("react", max_results=5)
+    assert len(results) == 5
+
+
+def test_published_after_is_30_days_ago() -> None:
+    now = datetime(2026, 4, 24, tzinfo=UTC)
+    ts = YouTubeDataAdapter._published_after(now)
+    assert ts.startswith("2026-03-25")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,25 @@
 import { AppShell } from "@/components/AppShell";
+import { ErrorBanner } from "@/components/ErrorBanner";
+import { KeywordInputView } from "@/components/KeywordInputView";
+import { VideoListView } from "@/components/VideoListView";
+import { useAppStore } from "@/store/useAppStore";
 
 export default function App() {
+  const { phase, error, setError } = useAppStore();
+
   return (
     <AppShell>
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium">Hello Dashboard</h2>
-        <p className="max-w-2xl text-sm text-fg-muted">
-          Phase 0-C Walking Skeleton. 사이드바 하단의 상태 도트가{" "}
-          <span className="font-mono text-accent">emerald</span> 이면 백엔드{" "}
-          <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-xs">/api/health</code> 가
-          응답하고 있다는 뜻입니다. 이후 Phase 1 (#11, #12, #13) 에서 키워드 입력 → 영상 리스트 →
-          분석 보고서 흐름이 이 자리에 렌더링됩니다.
-        </p>
+      {error ? (
+        <div className="mb-6">
+          <ErrorBanner error={error} onRetry={() => setError(null)} />
+        </div>
+      ) : null}
 
-        <dl className="grid max-w-md grid-cols-[auto_1fr] gap-x-6 gap-y-2 rounded-lg border border-border bg-bg-card p-5 text-sm">
-          <dt className="text-fg-muted">Phase</dt>
-          <dd className="font-mono">0-C · Walking Skeleton</dd>
-          <dt className="text-fg-muted">Issue</dt>
-          <dd className="font-mono">#7 (CI-7)</dd>
-          <dt className="text-fg-muted">Backend</dt>
-          <dd className="font-mono text-accent">/api/health → 200</dd>
-        </dl>
-      </section>
+      {phase === "input" ? <KeywordInputView /> : null}
+      {phase === "list" ? <VideoListView /> : null}
+      {phase === "analyzing" ? (
+        <p className="text-center text-sm text-fg-muted">분석 UI는 #13에서 구현됩니다.</p>
+      ) : null}
     </AppShell>
   );
 }

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -1,0 +1,32 @@
+import type { ApiError } from "@/lib/types";
+import { AlertCircle } from "lucide-react";
+
+interface ErrorBannerProps {
+  error: ApiError;
+  onRetry?: () => void;
+}
+
+export function ErrorBanner({ error, onRetry }: ErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      data-testid="error-banner"
+      className="mx-auto flex w-full max-w-2xl items-start gap-3 rounded-md border border-error/40 bg-error/10 p-4"
+    >
+      <AlertCircle size={18} className="mt-0.5 shrink-0 text-error" aria-hidden />
+      <div className="flex-1 text-sm">
+        <p className="font-medium text-error">{error.message}</p>
+        <p className="mt-1 font-mono text-[11px] text-fg-muted">code: {error.code}</p>
+      </div>
+      {onRetry && error.retryable ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded border border-error/40 px-3 py-1 text-xs text-error hover:bg-error/20"
+        >
+          다시 시도
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/KeywordInputView.tsx
+++ b/frontend/src/components/KeywordInputView.tsx
@@ -1,0 +1,79 @@
+import { searchVideos } from "@/lib/api";
+import { useAppStore } from "@/store/useAppStore";
+import { Search } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+export function KeywordInputView() {
+  const [value, setValue] = useState("");
+  const { setKeyword, setVideos, setError, setLoading, isLoading } = useAppStore();
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length >= 2 && trimmed.length <= 100 && !isLoading;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setLoading(true);
+    setError(null);
+    setKeyword(trimmed);
+    try {
+      const videos = await searchVideos(trimmed);
+      setVideos(videos);
+    } catch (err) {
+      const e = err as { code?: string; message?: string; retryable?: boolean };
+      setError({
+        code: e.code ?? "NETWORK",
+        message: e.message ?? "검색 중 문제가 생겼어요. 잠시 후 다시 시도해주세요.",
+        retryable: e.retryable ?? true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="mx-auto w-full max-w-2xl space-y-6">
+      <div>
+        <h2 className="text-lg font-medium">키워드 검색</h2>
+        <p className="mt-1 text-sm text-fg-muted">
+          최근 1개월 이내 YouTube 영상 5개를 찾아드릴게요.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex items-center gap-2" role="search">
+        <label htmlFor="keyword" className="sr-only">
+          검색어
+        </label>
+        <div className="relative flex-1">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+            aria-hidden
+          />
+          <input
+            id="keyword"
+            name="keyword"
+            data-testid="keyword-input"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder='예) "OpenAI Harness Engineering"'
+            minLength={2}
+            maxLength={100}
+            className="w-full rounded-md border border-border bg-bg-subtle py-2 pl-9 pr-3 text-sm placeholder:text-fg-subtle focus:border-accent focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          data-testid="keyword-submit"
+          className="rounded-md border border-border bg-bg-card px-4 py-2 text-sm font-medium text-fg hover:bg-bg-subtle disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading ? "검색 중…" : "검색"}
+        </button>
+      </form>
+
+      <p className="font-mono text-xs text-fg-subtle">
+        2–100자 · Enter 로 제출 · 최근 30일 이내 업로드만 노출
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/KeywordInputView.tsx
+++ b/frontend/src/components/KeywordInputView.tsx
@@ -39,7 +39,7 @@ export function KeywordInputView() {
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="flex items-center gap-2" role="search">
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
         <label htmlFor="keyword" className="sr-only">
           검색어
         </label>

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -1,0 +1,46 @@
+import type { VideoSearchResult } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Clock, PlayCircle } from "lucide-react";
+
+interface VideoCardProps {
+  video: VideoSearchResult;
+  selected?: boolean;
+  onSelect?: (videoId: string) => void;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toISOString().slice(0, 10);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}
+
+export function VideoCard({ video, selected = false, onSelect }: VideoCardProps) {
+  return (
+    <button
+      type="button"
+      data-testid="video-card"
+      data-video-id={video.videoId}
+      onClick={() => onSelect?.(video.videoId)}
+      className={cn(
+        "group flex w-full items-start gap-4 rounded-lg border bg-bg-card p-4 text-left transition",
+        selected
+          ? "border-accent shadow-[0_0_0_2px_rgba(34,197,94,0.3)]"
+          : "border-border hover:border-fg-subtle",
+      )}
+    >
+      <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-md bg-error/10 text-error">
+        <PlayCircle size={18} aria-hidden />
+      </span>
+      <div className="min-w-0 flex-1 space-y-1">
+        <h3 className="truncate text-sm font-medium text-fg">{video.title}</h3>
+        <p className="truncate font-mono text-xs text-fg-muted">{video.channelTitle}</p>
+        <p className="flex items-center gap-1 font-mono text-[11px] text-fg-subtle">
+          <Clock size={11} aria-hidden />
+          {formatDate(video.publishedAt)}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/VideoListView.tsx
+++ b/frontend/src/components/VideoListView.tsx
@@ -1,0 +1,43 @@
+import { VideoCard } from "@/components/VideoCard";
+import { useAppStore } from "@/store/useAppStore";
+
+export function VideoListView() {
+  const { keyword, videos, selectedVideoId, selectVideo, reset } = useAppStore();
+
+  return (
+    <section className="mx-auto w-full max-w-3xl space-y-6">
+      <header className="flex items-baseline justify-between">
+        <div>
+          <h2 className="text-lg font-medium">검색 결과</h2>
+          <p className="mt-1 text-sm text-fg-muted">
+            <span className="font-mono text-fg">"{keyword}"</span> 관련 최근 1개월 영상{" "}
+            <span className="font-mono text-fg">{videos.length}</span> 건
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="font-mono text-xs text-fg-subtle hover:text-fg"
+        >
+          ← 다른 키워드로 검색
+        </button>
+      </header>
+
+      <ul className="grid gap-3" data-testid="video-list">
+        {videos.map((video) => (
+          <li key={video.videoId}>
+            <VideoCard
+              video={video}
+              selected={video.videoId === selectedVideoId}
+              onSelect={selectVideo}
+            />
+          </li>
+        ))}
+      </ul>
+
+      <p className="font-mono text-[11px] text-fg-subtle">
+        영상을 하나 선택하면 다음 단계(분석)로 진행됩니다. (#12 에서 구현)
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+import type { ApiError, VideoSearchResult } from "@/lib/types";
+import axios, { type AxiosError } from "axios";
 
 export interface HealthData {
   status: "up" | "degraded" | "down";
@@ -6,17 +7,37 @@ export interface HealthData {
   version: string;
 }
 
-export interface HealthResponse {
+interface Envelope<T> {
   ok: boolean;
-  data: HealthData;
+  data: T;
+}
+
+interface ErrorEnvelope {
+  detail: ApiError;
 }
 
 const client = axios.create({
   baseURL: "/api",
-  timeout: 3000,
+  timeout: 10_000,
 });
 
 export async function fetchHealth(): Promise<HealthData> {
-  const response = await client.get<HealthResponse>("/health");
+  const response = await client.get<Envelope<HealthData>>("/health");
   return response.data.data;
+}
+
+export async function searchVideos(keyword: string): Promise<VideoSearchResult[]> {
+  try {
+    const response = await client.post<Envelope<{ videos: VideoSearchResult[] }>>("/search", {
+      keyword,
+    });
+    return response.data.data.videos;
+  } catch (err) {
+    const axiosErr = err as AxiosError<ErrorEnvelope>;
+    if (axiosErr.response?.data?.detail) {
+      const { code, message, retryable } = axiosErr.response.data.detail;
+      throw Object.assign(new Error(message), { code, retryable });
+    }
+    throw err;
+  }
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,15 @@
+export interface VideoSearchResult {
+  videoId: string;
+  title: string;
+  url: string;
+  publishedAt: string;
+  channelTitle: string;
+}
+
+export type Phase = "input" | "list" | "analyzing" | "result";
+
+export interface ApiError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -1,0 +1,39 @@
+import type { ApiError, Phase, VideoSearchResult } from "@/lib/types";
+import { create } from "zustand";
+
+interface AppState {
+  phase: Phase;
+  keyword: string;
+  videos: VideoSearchResult[];
+  selectedVideoId: string | null;
+  isLoading: boolean;
+  error: ApiError | null;
+
+  setKeyword: (keyword: string) => void;
+  setVideos: (videos: VideoSearchResult[]) => void;
+  selectVideo: (videoId: string) => void;
+  setLoading: (loading: boolean) => void;
+  setError: (error: ApiError | null) => void;
+  goTo: (phase: Phase) => void;
+  reset: () => void;
+}
+
+const INITIAL = {
+  phase: "input" as Phase,
+  keyword: "",
+  videos: [],
+  selectedVideoId: null,
+  isLoading: false,
+  error: null,
+};
+
+export const useAppStore = create<AppState>((set) => ({
+  ...INITIAL,
+  setKeyword: (keyword) => set({ keyword }),
+  setVideos: (videos) => set({ videos, phase: "list" }),
+  selectVideo: (videoId) => set({ selectedVideoId: videoId, phase: "analyzing" }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setError: (error) => set({ error }),
+  goTo: (phase) => set({ phase }),
+  reset: () => set(INITIAL),
+}));

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,12 +1,17 @@
 import App from "@/App";
+import { useAppStore } from "@/store/useAppStore";
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("App / AppShell", () => {
-  it("renders the brand title and header", () => {
+  beforeEach(() => {
+    useAppStore.getState().reset();
+  });
+
+  it("renders the brand title and starts in keyword-input phase", () => {
     render(<App />);
     expect(screen.getAllByText(/TechReport/).length).toBeGreaterThan(0);
-    expect(screen.getByText("Hello Dashboard")).toBeInTheDocument();
+    expect(screen.getByTestId("keyword-input")).toBeInTheDocument();
   });
 
   it("shows the health status dot eventually turning to Online", async () => {

--- a/frontend/tests/KeywordInputView.test.tsx
+++ b/frontend/tests/KeywordInputView.test.tsx
@@ -1,0 +1,31 @@
+import { KeywordInputView } from "@/components/KeywordInputView";
+import { useAppStore } from "@/store/useAppStore";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("KeywordInputView", () => {
+  beforeEach(() => {
+    useAppStore.getState().reset();
+  });
+
+  it("disables submit when keyword is too short", () => {
+    render(<KeywordInputView />);
+    const submit = screen.getByTestId("keyword-submit");
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("keyword-input"), { target: { value: "r" } });
+    expect(submit).toBeDisabled();
+  });
+
+  it("enables submit when keyword is ≥2 chars", () => {
+    render(<KeywordInputView />);
+    fireEvent.change(screen.getByTestId("keyword-input"), { target: { value: "react" } });
+    expect(screen.getByTestId("keyword-submit")).not.toBeDisabled();
+  });
+
+  it("trims whitespace-only input", () => {
+    render(<KeywordInputView />);
+    fireEvent.change(screen.getByTestId("keyword-input"), { target: { value: "   " } });
+    expect(screen.getByTestId("keyword-submit")).toBeDisabled();
+  });
+});

--- a/frontend/tests/VideoCard.test.tsx
+++ b/frontend/tests/VideoCard.test.tsx
@@ -1,0 +1,27 @@
+import { VideoCard } from "@/components/VideoCard";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const sampleVideo = {
+  videoId: "abc123",
+  title: "OpenAI Harness Engineering Deep Dive",
+  url: "https://www.youtube.com/watch?v=abc123",
+  publishedAt: "2026-04-15T10:00:00Z",
+  channelTitle: "Engineering Talks",
+};
+
+describe("VideoCard", () => {
+  it("renders title, channel and formatted date", () => {
+    render(<VideoCard video={sampleVideo} />);
+    expect(screen.getByText(sampleVideo.title)).toBeInTheDocument();
+    expect(screen.getByText(sampleVideo.channelTitle)).toBeInTheDocument();
+    expect(screen.getByText(/2026-04-15/)).toBeInTheDocument();
+  });
+
+  it("calls onSelect with videoId when clicked", () => {
+    const onSelect = vi.fn();
+    render(<VideoCard video={sampleVideo} onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId("video-card"));
+    expect(onSelect).toHaveBeenCalledWith("abc123");
+  });
+});


### PR DESCRIPTION
Closes #11

Phase 1 첫 수직 슬라이스. UI(KeywordInputView → VideoListView) + API(POST /api/search) + Adapter(YouTube Data v3) + Service(LRU cache) + 단위/통합 테스트.

### Backend
- `ports/youtube_search_port.py` + `adapters/youtube_data_adapter.py` (httpx + respx-mockable)
- `services/search_service.py` — asyncio-locked LRU 5분 TTL
- `api/search.py` — 422/404/502 코드 일관성
- tests: `test_youtube_adapter` (respx), `test_search_route` (TestClient)

### Frontend
- `lib/types.ts` + `lib/api.ts` (에러 매핑)
- Zustand store (`phase`/`keyword`/`videos`/`error`)
- `KeywordInputView` / `VideoCard` / `VideoListView` / `ErrorBanner`
- tests: submit-disable rules, card click → onSelect