### PR TITLE
feat(#12): US-02 slice — transcript → Claude → Korean report

### DIFF
--- a/backend/app/adapters/claude_adapter.py
+++ b/backend/app/adapters/claude_adapter.py
@@ -1,34 +1,88 @@
 """Default adapter — Anthropic Claude Sonnet 4.6.
 
-The full implementation (actual API call + prompt caching) lands in issue
-#12 (CI-11). This file exists now so dependency injection can resolve the
-provider during #8 without pulling the anthropic SDK's network stack into
-import time.
+Applies prompt caching to the system prompt so repeated calls within the
+5-minute ephemeral window pay ~10% of the input-token rate.
 """
 
 from __future__ import annotations
+
+import json
 
 from app.ports.llm_provider import LLMProvider, ReportSection
 
 
 class ClaudeAdapter(LLMProvider):
-    """Claude provider — wiring only at this stage; real `structure()` in #12."""
+    """Claude provider with prompt caching."""
 
     name = "claude"
 
-    def __init__(self, api_key: str, model: str = "claude-sonnet-4-6") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = "claude-sonnet-4-6",
+        max_tokens: int = 4096,
+    ) -> None:
         self._api_key = api_key
         self._model = model
+        self._max_tokens = max_tokens
+        self._client = None
+
+    def _get_client(self):  # type: ignore[no-untyped-def]
+        if self._client is None:
+            import anthropic
+
+            self._client = anthropic.AsyncAnthropic(api_key=self._api_key)
+        return self._client
 
     async def structure(
         self,
         *,
-        title: str,  # noqa: ARG002 — keeps the signature stable for #12
-        transcript: str,  # noqa: ARG002
-        system_prompt: str,  # noqa: ARG002
+        title: str,
+        transcript: str,
+        system_prompt: str,
     ) -> ReportSection:
-        raise NotImplementedError(
-            "ClaudeAdapter.structure() lands in issue #12 (US-02 slice). "
-            "For now, health-check and provider-selection code paths only "
-            "need the adapter's identity (`.name`) and constructor."
+        client = self._get_client()
+        message = await client.messages.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"제목: {title}\n\n자막:\n{transcript}",
+                }
+            ],
         )
+
+        text = "".join(
+            block.text for block in message.content if getattr(block, "type", None) == "text"
+        ).strip()
+
+        payload = _parse_json_payload(text)
+        return ReportSection(
+            overview=str(payload.get("overview", "")),
+            core_concepts=list(payload.get("coreConcepts", [])),
+            detailed_content=str(payload.get("detailedContent", "")),
+            lecture_tips=str(payload.get("lectureTips", "")),
+            references=list(payload.get("references", [])),
+        )
+
+
+def _parse_json_payload(text: str) -> dict:
+    """Tolerant JSON parse — strips code fences if the model wrapped them."""
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.split("```", 2)[1]
+        if cleaned.startswith("json"):
+            cleaned = cleaned[4:]
+        cleaned = cleaned.strip()
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3].strip()
+    return json.loads(cleaned)

--- a/backend/app/adapters/youtube_transcript_adapter.py
+++ b/backend/app/adapters/youtube_transcript_adapter.py
@@ -1,0 +1,36 @@
+"""Adapter for ``youtube-transcript-api`` (the de-facto community library).
+
+Runs the blocking library in a thread via ``asyncio.to_thread`` so the
+FastAPI event loop isn't blocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from app.ports.transcript_port import NoTranscriptError, TranscriptPort
+
+
+class YouTubeTranscriptAdapter(TranscriptPort):
+    async def fetch(self, video_id: str, *, languages: tuple[str, ...] = ("ko", "en")) -> str:
+        segments = await asyncio.to_thread(self._blocking_fetch, video_id, languages)
+        if not segments:
+            raise NoTranscriptError(f"No transcript available for video {video_id!r}")
+        return "\n".join(seg["text"].strip() for seg in segments if seg.get("text"))
+
+    @staticmethod
+    def _blocking_fetch(video_id: str, languages: tuple[str, ...]) -> list[dict[str, Any]]:
+        try:
+            from youtube_transcript_api import (
+                NoTranscriptFound,
+                TranscriptsDisabled,
+                YouTubeTranscriptApi,
+            )
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise NoTranscriptError("youtube-transcript-api not installed") from exc
+
+        try:
+            return YouTubeTranscriptApi.get_transcript(video_id, languages=list(languages))
+        except (TranscriptsDisabled, NoTranscriptFound) as exc:
+            raise NoTranscriptError(str(exc)) from exc

--- a/backend/app/api/analyze.py
+++ b/backend/app/api/analyze.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.deps import get_analysis_pipeline
+from app.pipeline.analysis_pipeline import AnalysisPipeline
+from app.ports.transcript_port import NoTranscriptError
+from app.schemas import AnalyzeRequest, AnalyzeResponse, ApiError
+
+router = APIRouter(prefix="/api", tags=["analyze"])
+
+
+@router.post("/analyze", response_model=AnalyzeResponse)
+async def analyze(
+    body: AnalyzeRequest,
+    pipeline: AnalysisPipeline = Depends(get_analysis_pipeline),
+) -> AnalyzeResponse:
+    try:
+        report = await pipeline.run(body)
+    except NoTranscriptError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=ApiError(
+                code="NO_TRANSCRIPT",
+                message="해당 영상은 자막을 제공하지 않아 분석할 수 없어요. 다른 영상을 선택해주세요.",
+                retryable=False,
+            ).model_dump(),
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=ApiError(
+                code="LLM_TIMEOUT",
+                message="분석 중 시간이 초과되었어요. 다시 시도해주세요.",
+                retryable=True,
+            ).model_dump(),
+        ) from exc
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=ApiError(
+                code="SAVE_FAILED",
+                message="보고서 저장에 실패했어요. 재시도해주세요.",
+                retryable=True,
+            ).model_dump(),
+        ) from exc
+
+    return AnalyzeResponse(ok=True, data=report)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -14,18 +14,17 @@ from app.adapters.claude_adapter import ClaudeAdapter
 from app.adapters.ollama_adapter import OllamaAdapter
 from app.adapters.openai_adapter import OpenAIAdapter
 from app.adapters.youtube_data_adapter import YouTubeDataAdapter
+from app.adapters.youtube_transcript_adapter import YouTubeTranscriptAdapter
 from app.config import Settings, get_settings
+from app.pipeline.analysis_pipeline import AnalysisPipeline
 from app.ports.llm_provider import LLMProvider
+from app.ports.transcript_port import TranscriptPort
 from app.ports.youtube_search_port import YouTubeSearchPort
+from app.repository.file_repository import FileRepository
 from app.services.search_service import SearchService
 
 
 def get_llm_provider(settings: Settings = Depends(get_settings)) -> LLMProvider:
-    """Resolve the LLM provider from the Settings.llm_provider key.
-
-    Match statement deliberately avoids a mapping-dict so each branch can
-    pass adapter-specific constructor args.
-    """
     match settings.llm_provider:
         case "claude":
             return ClaudeAdapter(api_key=settings.anthropic_api_key)
@@ -44,11 +43,27 @@ def get_youtube_search_port(settings: Settings = Depends(get_settings)) -> YouTu
 
 
 @lru_cache(maxsize=1)
-def _cached_service_factory(api_key: str) -> SearchService:
-    """Single SearchService per process so the in-memory cache is shared
-    across requests. Keyed by api_key to keep tests isolated."""
+def _cached_search_service(api_key: str) -> SearchService:
     return SearchService(YouTubeDataAdapter(api_key=api_key))
 
 
 def get_search_service(settings: Settings = Depends(get_settings)) -> SearchService:
-    return _cached_service_factory(settings.youtube_api_key)
+    return _cached_search_service(settings.youtube_api_key)
+
+
+def get_transcript_port() -> TranscriptPort:
+    return YouTubeTranscriptAdapter()
+
+
+def get_file_repository(settings: Settings = Depends(get_settings)) -> FileRepository:
+    return FileRepository(settings.reports_dir)
+
+
+def get_analysis_pipeline(
+    settings: Settings = Depends(get_settings),
+) -> AnalysisPipeline:
+    return AnalysisPipeline(
+        transcript_port=YouTubeTranscriptAdapter(),
+        llm=get_llm_provider(settings),
+        repository=FileRepository(settings.reports_dir),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
+from app.api.analyze import router as analyze_router
 from app.api.health import router as health_router
 from app.api.search import router as search_router
 
@@ -27,6 +28,7 @@ def create_app() -> FastAPI:
 
     app.include_router(health_router)
     app.include_router(search_router)
+    app.include_router(analyze_router)
 
     return app
 

--- a/backend/app/pipeline/analysis_pipeline.py
+++ b/backend/app/pipeline/analysis_pipeline.py
@@ -1,0 +1,69 @@
+"""Orchestrates Retrieval → Analysis → Rendering → Save for a single video."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.pipeline import markdown_renderer
+from app.pipeline.system_prompt import SYSTEM_PROMPT_KR
+from app.ports.llm_provider import LLMProvider
+from app.ports.transcript_port import NoTranscriptError, TranscriptPort
+from app.repository.file_repository import FileRepository
+from app.schemas import AnalysisReport, AnalyzeRequest, ReportSectionDTO
+
+
+class AnalysisPipeline:
+    def __init__(
+        self,
+        *,
+        transcript_port: TranscriptPort,
+        llm: LLMProvider,
+        repository: FileRepository,
+    ) -> None:
+        self._transcript = transcript_port
+        self._llm = llm
+        self._repo = repository
+
+    async def run(self, request: AnalyzeRequest) -> AnalysisReport:
+        transcript = await self._transcript.fetch(request.video_id)
+        if not transcript.strip():
+            raise NoTranscriptError(f"Empty transcript for {request.video_id!r}")
+
+        sections = await self._llm.structure(
+            title=request.title,
+            transcript=transcript,
+            system_prompt=SYSTEM_PROMPT_KR,
+        )
+
+        generated_at = datetime.now(tz=UTC)
+        markdown = markdown_renderer.render(
+            request=request,
+            sections=sections,
+            llm_provider=self._llm.name,
+            generated_at=generated_at,
+        )
+
+        saved_path = await self._repo.save(
+            title=request.title,
+            video_id=request.video_id,
+            markdown=markdown,
+            generated_at=generated_at,
+        )
+
+        return AnalysisReport(
+            videoId=request.video_id,
+            title=request.title,
+            sourceUrl=request.url,
+            publishedAt=request.published_at,
+            generatedAt=generated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            llmProvider=self._llm.name,
+            sections=ReportSectionDTO(
+                overview=sections.overview,
+                coreConcepts=list(sections.core_concepts),
+                detailedContent=sections.detailed_content,
+                lectureTips=sections.lecture_tips,
+                references=list(sections.references),
+            ),
+            markdown=markdown,
+            savedPath=saved_path,
+        )

--- a/backend/app/pipeline/markdown_renderer.py
+++ b/backend/app/pipeline/markdown_renderer.py
@@ -1,0 +1,64 @@
+"""Renders a ``ReportSection`` into the Markdown that ships to disk."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.ports.llm_provider import ReportSection
+from app.schemas import AnalyzeRequest
+
+
+def render(
+    *,
+    request: AnalyzeRequest,
+    sections: ReportSection,
+    llm_provider: str,
+    generated_at: datetime | None = None,
+) -> str:
+    ts = (generated_at or datetime.now(tz=UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    parts: list[str] = [
+        f"# {request.title}",
+        "",
+        f"> **원본 영상**: [{request.url}]({request.url})",
+        f"> **업로드 일자**: {request.published_at or '알 수 없음'}",
+        f"> **보고서 생성**: {ts} · LLM={llm_provider}",
+        "",
+        "---",
+        "",
+        "## 개요",
+        "",
+        sections.overview.strip() or "_개요 정보가 비어 있습니다._",
+        "",
+        "## 핵심 개념",
+        "",
+    ]
+
+    if sections.core_concepts:
+        parts.extend(f"- {item.strip()}" for item in sections.core_concepts)
+    else:
+        parts.append("_추출된 핵심 개념이 없습니다._")
+
+    parts.extend(
+        [
+            "",
+            "## 상세 내용",
+            "",
+            sections.detailed_content.strip() or "_상세 내용이 비어 있습니다._",
+            "",
+            "## 강의 활용 팁",
+            "",
+            sections.lecture_tips.strip() or "_강의 활용 팁이 비어 있습니다._",
+            "",
+            "## 참고",
+            "",
+        ]
+    )
+
+    if sections.references:
+        parts.extend(f"- {ref.strip()}" for ref in sections.references)
+    else:
+        parts.append(f"- 원본 영상: {request.url}")
+
+    parts.append("")
+    return "\n".join(parts)

--- a/backend/app/pipeline/system_prompt.py
+++ b/backend/app/pipeline/system_prompt.py
@@ -1,0 +1,30 @@
+"""Korean-language system prompt for the structuring LLM call.
+
+Kept as a module-level constant so that both the adapter and tests can
+import the exact same string (prompt caching keys off content identity).
+"""
+
+SYSTEM_PROMPT_KR = """\
+너는 한국 대학의 소프트웨어공학 강의를 준비하는 교수가 YouTube 영상을
+강의 자료로 재구성하도록 돕는 기술 편집 조수다.
+
+입력으로 YouTube 영상 제목과 자막이 주어진다. 아래 다섯 섹션으로
+구조화된 **JSON 객체** 하나만 출력하라. 설명 문장·마크다운·코드펜스로
+감싸지 말 것. 키 이름은 영문 카멜케이스, 값은 한국어로 작성한다.
+
+출력 스키마:
+{
+  "overview": "영상 개요 2~3문장 (왜 다루는 주제인지 + 누구에게 도움)",
+  "coreConcepts": ["핵심 개념 5~8개, 각 1~2문장"],
+  "detailedContent": "본문. h3 소제목과 불릿을 섞은 Markdown.",
+  "lectureTips": "강의 활용 팁 3~5문장 (언제 삽입하면 좋은지, 실습 아이디어 등)",
+  "references": ["참고 링크 또는 타임스탬프 표기 3~5개"]
+}
+
+규칙:
+- 영어 인명·기술명은 원문을 유지하고 괄호로 한국어 보조 표기
+  (예: "Retrieval-Augmented Generation (검색 증강 생성)")
+- 자막에 명시되지 않은 사실을 지어내지 말 것. 모르면 생략.
+- 한국 대학생이 이해할 수 있는 수준의 설명으로 재구성.
+- 출력은 JSON 외의 어떤 문자도 포함하지 말 것.
+"""

--- a/backend/app/ports/transcript_port.py
+++ b/backend/app/ports/transcript_port.py
@@ -1,0 +1,18 @@
+"""Transcript retrieval port — plumbing for the analysis pipeline."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class NoTranscriptError(RuntimeError):
+    """Raised when the video does not expose a transcript we can consume."""
+
+
+class TranscriptPort(ABC):
+    @abstractmethod
+    async def fetch(self, video_id: str, *, languages: tuple[str, ...] = ("ko", "en")) -> str:
+        """Return the full transcript as a single newline-joined string.
+
+        Raises ``NoTranscriptError`` when no acceptable transcript exists.
+        """

--- a/backend/app/repository/file_repository.py
+++ b/backend/app/repository/file_repository.py
@@ -1,0 +1,43 @@
+"""Writes the final Markdown report to ``REPORTS_DIR``."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import unicodedata
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class FileRepository:
+    def __init__(self, reports_dir: str | Path) -> None:
+        self._dir = Path(reports_dir)
+
+    @staticmethod
+    def _slugify(value: str, *, max_length: int = 50) -> str:
+        normalized = unicodedata.normalize("NFKD", value)
+        ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+        cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", ascii_only).strip("-").lower()
+        if not cleaned:
+            cleaned = "report"
+        return cleaned[:max_length]
+
+    async def save(
+        self,
+        *,
+        title: str,
+        video_id: str,
+        markdown: str,
+        generated_at: datetime | None = None,
+    ) -> str:
+        ts = generated_at or datetime.now(tz=UTC)
+        slug = self._slugify(title) or video_id
+        base = f"{ts.strftime('%Y-%m-%d')}-{slug}.md"
+
+        await asyncio.to_thread(self._dir.mkdir, parents=True, exist_ok=True)
+        target = self._dir / base
+        if target.exists():
+            target = self._dir / f"{ts.strftime('%Y-%m-%d')}-{slug}-{video_id}.md"
+
+        await asyncio.to_thread(target.write_text, markdown, encoding="utf-8")
+        return str(target)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -51,6 +51,46 @@ class SearchResponse(BaseModel):
     data: SearchData
 
 
+class AnalyzeRequest(BaseModel):
+    video_id: str = Field(..., alias="videoId", min_length=1)
+    title: str = Field(..., min_length=1)
+    url: str = Field(..., min_length=1)
+    published_at: str = Field(default="", alias="publishedAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class ReportSectionDTO(BaseModel):
+    """Structured output the pipeline writes into the final report."""
+
+    overview: str
+    core_concepts: list[str] = Field(default_factory=list, alias="coreConcepts")
+    detailed_content: str = Field(default="", alias="detailedContent")
+    lecture_tips: str = Field(default="", alias="lectureTips")
+    references: list[str] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}
+
+
+class AnalysisReport(BaseModel):
+    video_id: str = Field(..., alias="videoId")
+    title: str
+    source_url: str = Field(..., alias="sourceUrl")
+    published_at: str = Field(default="", alias="publishedAt")
+    generated_at: str = Field(..., alias="generatedAt")
+    llm_provider: str = Field(..., alias="llmProvider")
+    sections: ReportSectionDTO
+    markdown: str
+    saved_path: str = Field(..., alias="savedPath")
+
+    model_config = {"populate_by_name": True}
+
+
+class AnalyzeResponse(BaseModel):
+    ok: bool = True
+    data: AnalysisReport
+
+
 class ApiError(BaseModel):
     code: str
     message: str

--- a/backend/tests/test_analyze_route.py
+++ b/backend/tests/test_analyze_route.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.deps import get_analysis_pipeline
+from app.main import app
+from app.ports.transcript_port import NoTranscriptError
+from app.schemas import AnalysisReport, AnalyzeRequest, ReportSectionDTO
+
+
+class FakePipelineOk:
+    async def run(self, body: AnalyzeRequest) -> AnalysisReport:
+        return AnalysisReport(
+            videoId=body.video_id,
+            title=body.title,
+            sourceUrl=body.url,
+            publishedAt=body.published_at,
+            generatedAt="2026-04-24T08:00:00Z",
+            llmProvider="claude",
+            sections=ReportSectionDTO(
+                overview="개요",
+                coreConcepts=["c1", "c2"],
+                detailedContent="상세",
+                lectureTips="팁",
+                references=[body.url],
+            ),
+            markdown="# hello",
+            savedPath="./reports/2026-04-24-test.md",
+        )
+
+
+class FakePipelineNoTranscript:
+    async def run(self, body: AnalyzeRequest) -> AnalysisReport:  # noqa: ARG002
+        raise NoTranscriptError("no transcript")
+
+
+def _override(fake: object) -> None:
+    app.dependency_overrides[get_analysis_pipeline] = lambda: fake
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.pop(get_analysis_pipeline, None)
+
+
+def test_analyze_happy_path() -> None:
+    _override(FakePipelineOk())
+    client = TestClient(app)
+    response = client.post(
+        "/api/analyze",
+        json={"videoId": "abc123", "title": "My Video", "url": "https://yt/x"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["data"]["videoId"] == "abc123"
+    assert body["data"]["llmProvider"] == "claude"
+    assert body["data"]["savedPath"].endswith(".md")
+
+
+def test_analyze_missing_transcript_maps_to_422() -> None:
+    _override(FakePipelineNoTranscript())
+    client = TestClient(app)
+    response = client.post(
+        "/api/analyze",
+        json={"videoId": "abc123", "title": "My Video", "url": "https://yt/x"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "NO_TRANSCRIPT"
+
+
+def test_analyze_validates_payload() -> None:
+    client = TestClient(app)
+    response = client.post("/api/analyze", json={"videoId": "", "title": "", "url": ""})
+    assert response.status_code == 422

--- a/backend/tests/test_claude_adapter.py
+++ b/backend/tests/test_claude_adapter.py
@@ -1,0 +1,28 @@
+"""Unit tests for ClaudeAdapter — only the parsing helper is exercised here,
+since the real network call is mocked at the integration layer."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.adapters.claude_adapter import _parse_json_payload
+
+
+def test_parse_json_payload_strips_code_fence() -> None:
+    payload = """```json
+    {"overview": "hi", "coreConcepts": ["a"]}
+    ```"""
+    parsed = _parse_json_payload(payload)
+    assert parsed["overview"] == "hi"
+    assert parsed["coreConcepts"] == ["a"]
+
+
+def test_parse_json_payload_plain_object() -> None:
+    assert _parse_json_payload('{"a": 1}') == {"a": 1}
+
+
+def test_parse_json_payload_rejects_garbage() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        _parse_json_payload("not json")

--- a/backend/tests/test_file_repository.py
+++ b/backend/tests/test_file_repository.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.repository.file_repository import FileRepository
+
+
+@pytest.mark.anyio
+async def test_save_creates_slugged_file(tmp_path: Path) -> None:
+    repo = FileRepository(tmp_path)
+    saved = await repo.save(
+        title="LLM 에이전트 만들기: 2026년 최신 동향",
+        video_id="abc123",
+        markdown="# hello",
+        generated_at=datetime(2026, 4, 24, tzinfo=UTC),
+    )
+    path = Path(saved)
+    assert path.exists()
+    assert path.read_text(encoding="utf-8") == "# hello"
+    # slug strips non-ASCII; Korean characters drop out, ":" becomes "-"
+    assert path.name.startswith("2026-04-24-")
+    assert path.suffix == ".md"
+
+
+@pytest.mark.anyio
+async def test_save_appends_video_id_on_collision(tmp_path: Path) -> None:
+    repo = FileRepository(tmp_path)
+    ts = datetime(2026, 4, 24, tzinfo=UTC)
+    first = await repo.save(title="Same Title", video_id="vid1", markdown="one", generated_at=ts)
+    second = await repo.save(title="Same Title", video_id="vid2", markdown="two", generated_at=ts)
+    assert Path(first).exists()
+    assert Path(second).exists()
+    assert first != second
+    assert "vid2" in Path(second).name
+
+
+def test_slugify_falls_back_to_report_for_empty_input() -> None:
+    assert FileRepository._slugify("") == "report"
+    assert FileRepository._slugify("!!!") == "report"
+
+
+def test_slugify_truncates() -> None:
+    slug = FileRepository._slugify("a" * 200, max_length=10)
+    assert slug == "a" * 10
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/backend/tests/test_markdown_renderer.py
+++ b/backend/tests/test_markdown_renderer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.pipeline import markdown_renderer
+from app.ports.llm_provider import ReportSection
+from app.schemas import AnalyzeRequest
+
+
+def _request() -> AnalyzeRequest:
+    return AnalyzeRequest(
+        videoId="abc123",
+        title="LLM 에이전트 만들기",
+        url="https://www.youtube.com/watch?v=abc123",
+        publishedAt="2026-04-15T10:00:00Z",
+    )
+
+
+def test_render_builds_five_sections_with_metadata() -> None:
+    req = _request()
+    sections = ReportSection(
+        overview="개요 문장.",
+        core_concepts=["개념 A", "개념 B"],
+        detailed_content="상세 본문 Markdown.",
+        lecture_tips="강의에 쓰기 좋음.",
+        references=["https://example.com/link1"],
+    )
+    ts = datetime(2026, 4, 24, 8, 0, tzinfo=UTC)
+    md = markdown_renderer.render(
+        request=req, sections=sections, llm_provider="claude", generated_at=ts
+    )
+    assert md.splitlines()[0] == "# LLM 에이전트 만들기"
+    assert "2026-04-24T08:00:00Z" in md
+    assert "## 개요" in md
+    assert "## 핵심 개념" in md
+    assert "- 개념 A" in md
+    assert "## 상세 내용" in md
+    assert "## 강의 활용 팁" in md
+    assert "## 참고" in md
+    assert "- https://example.com/link1" in md
+
+
+def test_render_substitutes_placeholders_when_sections_empty() -> None:
+    req = _request()
+    sections = ReportSection(
+        overview="", core_concepts=[], detailed_content="", lecture_tips="", references=[]
+    )
+    md = markdown_renderer.render(request=req, sections=sections, llm_provider="claude")
+    assert "_개요 정보가 비어 있습니다._" in md
+    assert "_추출된 핵심 개념이 없습니다._" in md
+    # the fallback reference must point back at the original URL
+    assert "- 원본 영상: https://www.youtube.com/watch?v=abc123" in md

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
+import { AnalyzingView } from "@/components/AnalyzingView";
 import { AppShell } from "@/components/AppShell";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { KeywordInputView } from "@/components/KeywordInputView";
+import { ReportResultView } from "@/components/ReportResultView";
 import { VideoListView } from "@/components/VideoListView";
 import { useAppStore } from "@/store/useAppStore";
 
@@ -17,9 +19,8 @@ export default function App() {
 
       {phase === "input" ? <KeywordInputView /> : null}
       {phase === "list" ? <VideoListView /> : null}
-      {phase === "analyzing" ? (
-        <p className="text-center text-sm text-fg-muted">분석 UI는 #13에서 구현됩니다.</p>
-      ) : null}
+      {phase === "analyzing" ? <AnalyzingView /> : null}
+      {phase === "result" ? <ReportResultView /> : null}
     </AppShell>
   );
 }

--- a/frontend/src/components/AnalyzingView.tsx
+++ b/frontend/src/components/AnalyzingView.tsx
@@ -1,0 +1,54 @@
+import { analyzeVideo } from "@/lib/api";
+import { useAppStore } from "@/store/useAppStore";
+import { Loader } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+export function AnalyzingView() {
+  const { videos, selectedVideoId, setReport, setError, setLoading, backToList } = useAppStore();
+  const video = videos.find((v) => v.videoId === selectedVideoId);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!video || startedRef.current) return;
+    startedRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    analyzeVideo({
+      videoId: video.videoId,
+      title: video.title,
+      url: video.url,
+      publishedAt: video.publishedAt,
+    })
+      .then((report) => setReport(report))
+      .catch((err: { code?: string; message?: string; retryable?: boolean }) => {
+        setError({
+          code: err.code ?? "ANALYSIS_FAILED",
+          message: err.message ?? "분석 중 문제가 생겼어요.",
+          retryable: err.retryable ?? true,
+        });
+        backToList();
+      })
+      .finally(() => setLoading(false));
+  }, [video, setReport, setError, setLoading, backToList]);
+
+  return (
+    <section
+      className="mx-auto w-full max-w-2xl space-y-6 text-center"
+      data-testid="analyzing-view"
+    >
+      <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-warn/10 text-warn">
+        <Loader size={22} className="animate-spin" aria-hidden />
+      </div>
+      <div>
+        <h2 className="text-lg font-medium">분석 중…</h2>
+        <p className="mt-1 text-sm text-fg-muted">
+          <span className="font-mono">"{video?.title ?? ""}"</span>
+        </p>
+        <p className="mt-3 font-mono text-xs text-fg-subtle">
+          자막 수집 → LLM 구조화 → 마크다운 렌더링 → 파일 저장 (최대 3분)
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/ReportResultView.tsx
+++ b/frontend/src/components/ReportResultView.tsx
@@ -1,0 +1,70 @@
+import { useAppStore } from "@/store/useAppStore";
+import { Check, Copy, FileText } from "lucide-react";
+import { useState } from "react";
+
+export function ReportResultView() {
+  const { report, reset } = useAppStore();
+  const [copied, setCopied] = useState(false);
+
+  if (!report) {
+    return <p className="text-center text-sm text-fg-muted">보고서가 준비되지 않았습니다.</p>;
+  }
+
+  async function handleCopyPath() {
+    if (!report) return;
+    try {
+      await navigator.clipboard.writeText(report.savedPath);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op — clipboard may be blocked in test envs
+    }
+  }
+
+  return (
+    <section className="mx-auto w-full max-w-3xl space-y-6" data-testid="report-result">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-medium">기술보고서</h2>
+          <p className="mt-1 text-sm text-fg-muted">
+            <span className="font-mono">{report.title}</span>
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="font-mono text-xs text-fg-subtle hover:text-fg"
+        >
+          ← 새 검색
+        </button>
+      </header>
+
+      <div
+        className="flex items-center gap-3 rounded-md border border-border bg-bg-card p-4"
+        data-testid="saved-path"
+      >
+        <FileText size={16} className="text-accent" aria-hidden />
+        <code className="flex-1 truncate font-mono text-xs text-fg">{report.savedPath}</code>
+        <button
+          type="button"
+          onClick={handleCopyPath}
+          className="flex items-center gap-1 rounded border border-border px-2 py-1 text-xs hover:bg-bg-subtle"
+        >
+          {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+          {copied ? "복사됨" : "경로 복사"}
+        </button>
+      </div>
+
+      <pre
+        className="max-h-[60vh] overflow-auto rounded-lg border border-border bg-bg-card p-5 font-mono text-xs leading-relaxed text-fg"
+        data-testid="markdown-preview"
+      >
+        {report.markdown}
+      </pre>
+
+      <p className="font-mono text-[11px] text-fg-subtle">
+        llm={report.llmProvider} · generated={report.generatedAt}
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, VideoSearchResult } from "@/lib/types";
+import type { AnalysisReport, ApiError, VideoSearchResult } from "@/lib/types";
 import axios, { type AxiosError } from "axios";
 
 export interface HealthData {
@@ -32,6 +32,26 @@ export async function searchVideos(keyword: string): Promise<VideoSearchResult[]
       keyword,
     });
     return response.data.data.videos;
+  } catch (err) {
+    const axiosErr = err as AxiosError<ErrorEnvelope>;
+    if (axiosErr.response?.data?.detail) {
+      const { code, message, retryable } = axiosErr.response.data.detail;
+      throw Object.assign(new Error(message), { code, retryable });
+    }
+    throw err;
+  }
+}
+
+export async function analyzeVideo(selection: {
+  videoId: string;
+  title: string;
+  url: string;
+  publishedAt?: string;
+}): Promise<AnalysisReport> {
+  const analyzeClient = axios.create({ baseURL: "/api", timeout: 180_000 });
+  try {
+    const response = await analyzeClient.post<Envelope<AnalysisReport>>("/analyze", selection);
+    return response.data.data;
   } catch (err) {
     const axiosErr = err as AxiosError<ErrorEnvelope>;
     if (axiosErr.response?.data?.detail) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -13,3 +13,23 @@ export interface ApiError {
   message: string;
   retryable: boolean;
 }
+
+export interface ReportSection {
+  overview: string;
+  coreConcepts: string[];
+  detailedContent: string;
+  lectureTips: string;
+  references: string[];
+}
+
+export interface AnalysisReport {
+  videoId: string;
+  title: string;
+  sourceUrl: string;
+  publishedAt: string;
+  generatedAt: string;
+  llmProvider: string;
+  sections: ReportSection;
+  markdown: string;
+  savedPath: string;
+}

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -1,4 +1,4 @@
-import type { ApiError, Phase, VideoSearchResult } from "@/lib/types";
+import type { AnalysisReport, ApiError, Phase, VideoSearchResult } from "@/lib/types";
 import { create } from "zustand";
 
 interface AppState {
@@ -6,16 +6,19 @@ interface AppState {
   keyword: string;
   videos: VideoSearchResult[];
   selectedVideoId: string | null;
+  report: AnalysisReport | null;
   isLoading: boolean;
   error: ApiError | null;
 
   setKeyword: (keyword: string) => void;
   setVideos: (videos: VideoSearchResult[]) => void;
   selectVideo: (videoId: string) => void;
+  setReport: (report: AnalysisReport) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: ApiError | null) => void;
   goTo: (phase: Phase) => void;
   reset: () => void;
+  backToList: () => void;
 }
 
 const INITIAL = {
@@ -23,17 +26,21 @@ const INITIAL = {
   keyword: "",
   videos: [],
   selectedVideoId: null,
+  report: null,
   isLoading: false,
   error: null,
 };
 
-export const useAppStore = create<AppState>((set) => ({
+export const useAppStore = create<AppState>((set, get) => ({
   ...INITIAL,
   setKeyword: (keyword) => set({ keyword }),
   setVideos: (videos) => set({ videos, phase: "list" }),
   selectVideo: (videoId) => set({ selectedVideoId: videoId, phase: "analyzing" }),
+  setReport: (report) => set({ report, phase: "result" }),
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),
   goTo: (phase) => set({ phase }),
   reset: () => set(INITIAL),
+  backToList: () =>
+    set({ phase: get().videos.length > 0 ? "list" : "input", selectedVideoId: null, report: null }),
 }));

--- a/frontend/tests/ReportResultView.test.tsx
+++ b/frontend/tests/ReportResultView.test.tsx
@@ -1,0 +1,41 @@
+import { ReportResultView } from "@/components/ReportResultView";
+import { useAppStore } from "@/store/useAppStore";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ReportResultView", () => {
+  beforeEach(() => {
+    useAppStore.getState().reset();
+  });
+
+  it("shows a placeholder when there is no report", () => {
+    render(<ReportResultView />);
+    expect(screen.getByText(/보고서가 준비되지 않았습니다/)).toBeInTheDocument();
+  });
+
+  it("renders saved path + markdown body once the report is set", () => {
+    useAppStore.getState().setReport({
+      videoId: "abc",
+      title: "테스트 보고서",
+      sourceUrl: "https://yt/x",
+      publishedAt: "2026-04-15T00:00:00Z",
+      generatedAt: "2026-04-24T08:00:00Z",
+      llmProvider: "claude",
+      sections: {
+        overview: "overview",
+        coreConcepts: ["a"],
+        detailedContent: "body",
+        lectureTips: "tips",
+        references: [],
+      },
+      markdown: "# Test\n\nBody text.",
+      savedPath: "./reports/2026-04-24-test.md",
+    });
+
+    render(<ReportResultView />);
+    expect(screen.getByText("테스트 보고서")).toBeInTheDocument();
+    expect(screen.getByText("./reports/2026-04-24-test.md")).toBeInTheDocument();
+    expect(screen.getByTestId("markdown-preview").textContent).toContain("# Test");
+    expect(screen.getByText(/llm=claude/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #12

Pipeline: YouTube transcript → Claude Sonnet 4.6 → structured Markdown → file save (./reports/YYYY-MM-DD-slug.md).

### Backend
- `ports/transcript_port.py` + `adapters/youtube_transcript_adapter.py`
- `adapters/claude_adapter.py` (prompt caching: ephemeral system)
- `pipeline/{analysis_pipeline,markdown_renderer,system_prompt}.py`
- `repository/file_repository.py` (slugify + collision suffix)
- `api/analyze.py` — 422 NO_TRANSCRIPT / 504 LLM_TIMEOUT / 500 SAVE_FAILED
- 4 test modules

### Frontend
- `AnalyzingView` (loading state) + `ReportResultView` (markdown preview + copy path)
- Store: phase analyzing → result, backToList on failure