### PR TITLE
feat(#13): AnalyzingView polish — LogStream + ProgressBar

### DIFF
--- a/frontend/src/components/AnalyzingView.tsx
+++ b/frontend/src/components/AnalyzingView.tsx
@@ -1,18 +1,46 @@
+import { LogStream } from "@/components/LogStream";
+import { ProgressBar } from "@/components/ProgressBar";
 import { analyzeVideo } from "@/lib/api";
 import { useAppStore } from "@/store/useAppStore";
 import { Loader } from "lucide-react";
 import { useEffect, useRef } from "react";
 
+interface Step {
+  /** at what progress % the message should appear */
+  atPct: number;
+  /** after which delay (ms from phase entry) to push the message */
+  atMs: number;
+  message: string;
+}
+
+const STEPS: Step[] = [
+  { atMs: 0, atPct: 5, message: "파이프라인 시작" },
+  { atMs: 600, atPct: 25, message: "자막 가져오는 중…" },
+  { atMs: 2200, atPct: 50, message: "Claude Sonnet 으로 한국어 구조화 중…" },
+  { atMs: 4500, atPct: 75, message: "마크다운으로 렌더링 중…" },
+  { atMs: 6500, atPct: 90, message: "./reports 디렉토리에 저장 중…" },
+];
+
 export function AnalyzingView() {
-  const { videos, selectedVideoId, setReport, setError, setLoading, backToList } = useAppStore();
+  const { videos, selectedVideoId, statusLog, setReport, setError, backToList, pushLog } =
+    useAppStore();
   const video = videos.find((v) => v.videoId === selectedVideoId);
   const startedRef = useRef(false);
+  const progressRef = useRef(5);
 
   useEffect(() => {
     if (!video || startedRef.current) return;
     startedRef.current = true;
-    setLoading(true);
-    setError(null);
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (const step of STEPS) {
+      timers.push(
+        setTimeout(() => {
+          pushLog(step.message, "info");
+          progressRef.current = step.atPct;
+        }, step.atMs),
+      );
+    }
 
     analyzeVideo({
       videoId: video.videoId,
@@ -20,35 +48,49 @@ export function AnalyzingView() {
       url: video.url,
       publishedAt: video.publishedAt,
     })
-      .then((report) => setReport(report))
+      .then((report) => {
+        pushLog(`저장 완료: ${report.savedPath}`, "success");
+        setReport(report);
+      })
       .catch((err: { code?: string; message?: string; retryable?: boolean }) => {
+        const message = err.message ?? "분석 중 문제가 생겼어요.";
+        pushLog(message, "error");
         setError({
           code: err.code ?? "ANALYSIS_FAILED",
-          message: err.message ?? "분석 중 문제가 생겼어요.",
+          message,
           retryable: err.retryable ?? true,
         });
         backToList();
-      })
-      .finally(() => setLoading(false));
-  }, [video, setReport, setError, setLoading, backToList]);
+      });
+
+    return () => {
+      for (const t of timers) clearTimeout(t);
+    };
+  }, [video, setReport, setError, backToList, pushLog]);
+
+  const progress = statusLog.length === 0 ? 5 : Math.max(progressRef.current, 10);
 
   return (
-    <section
-      className="mx-auto w-full max-w-2xl space-y-6 text-center"
-      data-testid="analyzing-view"
-    >
-      <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-warn/10 text-warn">
-        <Loader size={22} className="animate-spin" aria-hidden />
-      </div>
-      <div>
-        <h2 className="text-lg font-medium">분석 중…</h2>
-        <p className="mt-1 text-sm text-fg-muted">
-          <span className="font-mono">"{video?.title ?? ""}"</span>
-        </p>
-        <p className="mt-3 font-mono text-xs text-fg-subtle">
-          자막 수집 → LLM 구조화 → 마크다운 렌더링 → 파일 저장 (최대 3분)
-        </p>
-      </div>
+    <section className="mx-auto w-full max-w-2xl space-y-6" data-testid="analyzing-view">
+      <header className="flex items-start gap-3">
+        <div className="grid h-12 w-12 place-items-center rounded-full bg-warn/10 text-warn">
+          <Loader size={22} className="animate-spin" aria-hidden />
+        </div>
+        <div>
+          <h2 className="text-lg font-medium">분석 중…</h2>
+          <p className="mt-1 text-sm text-fg-muted">
+            <span className="font-mono">{video?.title ?? ""}</span>
+          </p>
+        </div>
+      </header>
+
+      <ProgressBar value={progress} label="Pipeline" />
+
+      <LogStream entries={statusLog} />
+
+      <p className="font-mono text-[11px] text-fg-subtle">
+        파이프라인 단계: 자막 수집 → LLM 구조화 → 마크다운 렌더링 → 파일 저장 · 최대 3분 소요
+      </p>
     </section>
   );
 }

--- a/frontend/src/components/LogStream.tsx
+++ b/frontend/src/components/LogStream.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/lib/utils";
+import type { StatusLogEntry } from "@/store/useAppStore";
+import { useEffect, useRef } from "react";
+
+interface LogStreamProps {
+  entries: StatusLogEntry[];
+  className?: string;
+}
+
+const LEVEL_COLOR: Record<StatusLogEntry["level"], string> = {
+  info: "text-fg-muted",
+  success: "text-accent",
+  error: "text-error",
+};
+
+function formatTime(): string {
+  return new Date().toISOString().slice(11, 19);
+}
+
+export function LogStream({ entries, className }: LogStreamProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const length = entries.length;
+  useEffect(() => {
+    const el = ref.current;
+    if (el && length > 0) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [length]);
+
+  return (
+    <div
+      ref={ref}
+      data-testid="log-stream"
+      aria-live="polite"
+      className={cn(
+        "h-48 overflow-auto rounded-md border border-border bg-bg-subtle p-3 font-mono text-[13px] leading-relaxed",
+        className,
+      )}
+    >
+      {entries.length === 0 ? (
+        <p className="text-fg-subtle">대기 중…</p>
+      ) : (
+        entries.map((entry) => (
+          <div key={entry.id} className="flex gap-2">
+            <span className="shrink-0 text-fg-subtle">{formatTime()}</span>
+            <span className={LEVEL_COLOR[entry.level]}>{entry.message}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface ProgressBarProps {
+  value: number;
+  label?: string;
+  className?: string;
+}
+
+export function ProgressBar({ value, label, className }: ProgressBarProps) {
+  const pct = Math.max(0, Math.min(100, value));
+  return (
+    <div className={cn("space-y-1", className)} data-testid="progress-bar">
+      <div className="flex justify-between font-mono text-[11px] text-fg-subtle">
+        <span>{label ?? "진행률"}</span>
+        <span>{pct.toFixed(0)}%</span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-card">
+        <div
+          className="h-full rounded-full bg-warn transition-[width] duration-500 ease-out"
+          style={{ width: `${pct}%` }}
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={label ?? "Analysis progress"}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -1,6 +1,12 @@
 import type { AnalysisReport, ApiError, Phase, VideoSearchResult } from "@/lib/types";
 import { create } from "zustand";
 
+export interface StatusLogEntry {
+  id: number;
+  message: string;
+  level: "info" | "success" | "error";
+}
+
 interface AppState {
   phase: Phase;
   keyword: string;
@@ -9,6 +15,7 @@ interface AppState {
   report: AnalysisReport | null;
   isLoading: boolean;
   error: ApiError | null;
+  statusLog: StatusLogEntry[];
 
   setKeyword: (keyword: string) => void;
   setVideos: (videos: VideoSearchResult[]) => void;
@@ -19,6 +26,8 @@ interface AppState {
   goTo: (phase: Phase) => void;
   reset: () => void;
   backToList: () => void;
+  pushLog: (message: string, level?: StatusLogEntry["level"]) => void;
+  clearLog: () => void;
 }
 
 const INITIAL = {
@@ -29,18 +38,30 @@ const INITIAL = {
   report: null,
   isLoading: false,
   error: null,
+  statusLog: [] as StatusLogEntry[],
 };
+
+let logCounter = 0;
 
 export const useAppStore = create<AppState>((set, get) => ({
   ...INITIAL,
   setKeyword: (keyword) => set({ keyword }),
   setVideos: (videos) => set({ videos, phase: "list" }),
-  selectVideo: (videoId) => set({ selectedVideoId: videoId, phase: "analyzing" }),
+  selectVideo: (videoId) => set({ selectedVideoId: videoId, phase: "analyzing", statusLog: [] }),
   setReport: (report) => set({ report, phase: "result" }),
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),
   goTo: (phase) => set({ phase }),
-  reset: () => set(INITIAL),
+  reset: () => set({ ...INITIAL, statusLog: [] }),
   backToList: () =>
-    set({ phase: get().videos.length > 0 ? "list" : "input", selectedVideoId: null, report: null }),
+    set({
+      phase: get().videos.length > 0 ? "list" : "input",
+      selectedVideoId: null,
+      report: null,
+    }),
+  pushLog: (message, level = "info") =>
+    set((state) => ({
+      statusLog: [...state.statusLog, { id: ++logCounter, message, level }],
+    })),
+  clearLog: () => set({ statusLog: [] }),
 }));

--- a/frontend/tests/AnalyzingView.test.tsx
+++ b/frontend/tests/AnalyzingView.test.tsx
@@ -1,0 +1,47 @@
+import { AnalyzingView } from "@/components/AnalyzingView";
+import { useAppStore } from "@/store/useAppStore";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("AnalyzingView", () => {
+  beforeEach(() => {
+    useAppStore.getState().reset();
+    vi.useFakeTimers();
+    // Seed the store with a video + selection so AnalyzingView has something to render
+    useAppStore.setState({
+      phase: "analyzing",
+      videos: [
+        {
+          videoId: "abc",
+          title: "Demo Video",
+          url: "https://yt/x",
+          publishedAt: "2026-04-15T00:00:00Z",
+          channelTitle: "Demo",
+        },
+      ],
+      selectedVideoId: "abc",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders spinner + video title + empty log placeholder at start", () => {
+    render(<AnalyzingView />);
+    expect(screen.getByText("분석 중…")).toBeInTheDocument();
+    expect(screen.getByText("Demo Video")).toBeInTheDocument();
+    expect(screen.getByTestId("progress-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("log-stream")).toBeInTheDocument();
+  });
+
+  it("pushes at least 3 log lines over time", () => {
+    render(<AnalyzingView />);
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    const entries = useAppStore.getState().statusLog;
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+    expect(entries[0].message).toContain("파이프라인");
+  });
+});


### PR DESCRIPTION
Closes #13

분석 중 3분간의 침묵 대신 단계별 메시지를 순차 표시. 백엔드 변경 없음 (AC option 2).

- `LogStream` — JetBrains Mono 13px, auto-scroll, info/success/error 3색
- `ProgressBar` — warn 색상 슬림 바 + %
- `AnalyzingView` — 5단계 타이머 (5/25/50/75/90%) + success 녹색 + error 빨강
- Store: `statusLog[]` + `pushLog()` + select 시 clear
- 테스트: fake timers 로 3초 advance → 로그 ≥3줄 검증