### PR TITLE
feat(#14): US-01 edge cases — EmptyState + typed errors

### DIFF
--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -15,6 +15,9 @@ async def search(
     body: SearchRequest,
     service: SearchService = Depends(get_search_service),
 ) -> SearchResponse:
+    """Return up to 5 recent videos. Empty result is ``data.videos == []``
+    (HTTP 200), not an error — "no match" is a valid outcome for a rare
+    keyword, not a server problem."""
     try:
         videos = await service.search(body.keyword)
     except httpx.HTTPStatusError as exc:
@@ -35,15 +38,5 @@ async def search(
                 retryable=True,
             ).model_dump(),
         ) from exc
-
-    if not videos:
-        raise HTTPException(
-            status_code=404,
-            detail=ApiError(
-                code="NO_RESULTS",
-                message="최근 1개월 이내 관련 영상을 찾지 못했어요.",
-                retryable=False,
-            ).model_dump(),
-        )
 
     return SearchResponse(ok=True, data=SearchData(videos=videos))

--- a/backend/tests/test_search_route.py
+++ b/backend/tests/test_search_route.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -19,7 +21,7 @@ class FakeService:
 
 
 @pytest.fixture(autouse=True)
-def reset_overrides() -> None:
+def reset_overrides():
     app.dependency_overrides.pop(get_search_service, None)
     yield
     app.dependency_overrides.pop(get_search_service, None)
@@ -35,7 +37,7 @@ def _sample_video(i: int = 0) -> VideoSearchResult:
     )
 
 
-def _override_with(fake: FakeService) -> None:
+def _override_with(fake: object) -> None:
     app.dependency_overrides[get_search_service] = lambda: fake
 
 
@@ -58,10 +60,36 @@ def test_keyword_too_short_returns_422() -> None:
     assert response.status_code == 422
 
 
-def test_empty_result_returns_404_with_no_results_code() -> None:
+def test_empty_result_returns_200_with_empty_list() -> None:
+    """No-results is not an error — it's a normal 200 with data.videos=[]."""
     _override_with(FakeService([]))
     client = TestClient(app)
     response = client.post("/api/search", json={"keyword": "zzzxxxyyy"})
-    assert response.status_code == 404
+    assert response.status_code == 200
     body = response.json()
-    assert body["detail"]["code"] == "NO_RESULTS"
+    assert body["ok"] is True
+    assert body["data"]["videos"] == []
+
+
+def test_youtube_http_error_returns_502_with_code() -> None:
+    service = AsyncMock()
+    request = httpx.Request("GET", "https://example")
+    response = httpx.Response(503, request=request)
+    service.search.side_effect = httpx.HTTPStatusError("boom", request=request, response=response)
+    _override_with(service)
+    client = TestClient(app)
+    resp = client.post("/api/search", json={"keyword": "react"})
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "YOUTUBE_API_ERROR"
+    assert resp.json()["detail"]["retryable"] is True
+
+
+def test_youtube_unreachable_returns_502() -> None:
+    service = AsyncMock()
+    request = httpx.Request("GET", "https://example")
+    service.search.side_effect = httpx.ConnectError("dns fail", request=request)
+    _override_with(service)
+    client = TestClient(app)
+    resp = client.post("/api/search", json={"keyword": "react"})
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "YOUTUBE_API_ERROR"

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,35 @@
+import { SearchX } from "lucide-react";
+
+interface EmptyStateProps {
+  keyword: string;
+  onRetry: () => void;
+}
+
+export function EmptyState({ keyword, onRetry }: EmptyStateProps) {
+  return (
+    <section
+      className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 rounded-lg border border-dashed border-border bg-bg-subtle p-10 text-center"
+      data-testid="empty-state"
+    >
+      <span className="grid h-12 w-12 place-items-center rounded-full bg-fg-muted/10 text-fg-muted">
+        <SearchX size={22} aria-hidden />
+      </span>
+      <div className="space-y-1">
+        <h3 className="text-base font-medium text-fg">검색 결과가 없어요</h3>
+        <p className="text-sm text-fg-muted">
+          <span className="font-mono text-fg">"{keyword}"</span> 관련 최근 1개월 이내 영상을 찾지
+          못했어요.
+        </p>
+        <p className="text-sm text-fg-muted">키워드를 바꿔서 다시 시도해보세요.</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-md border border-border bg-bg-card px-4 py-2 text-sm font-medium text-fg hover:bg-bg-subtle"
+        data-testid="empty-state-retry"
+      >
+        다른 키워드로 검색
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/components/KeywordInputView.tsx
+++ b/frontend/src/components/KeywordInputView.tsx
@@ -17,6 +17,7 @@ export function KeywordInputView() {
     setKeyword(trimmed);
     try {
       const videos = await searchVideos(trimmed);
+      // Empty list is a valid success — VideoListView renders an EmptyState
       setVideos(videos);
     } catch (err) {
       const e = err as { code?: string; message?: string; retryable?: boolean };
@@ -46,7 +47,7 @@ export function KeywordInputView() {
         <div className="relative flex-1">
           <Search
             size={16}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+            className="-translate-y-1/2 absolute top-1/2 left-3 text-fg-subtle"
             aria-hidden
           />
           <input
@@ -58,20 +59,20 @@ export function KeywordInputView() {
             placeholder='예) "OpenAI Harness Engineering"'
             minLength={2}
             maxLength={100}
-            className="w-full rounded-md border border-border bg-bg-subtle py-2 pl-9 pr-3 text-sm placeholder:text-fg-subtle focus:border-accent focus:outline-none"
+            className="w-full rounded-md border border-border bg-bg-subtle py-2 pr-3 pl-9 text-sm placeholder:text-fg-subtle focus:border-accent focus:outline-none"
           />
         </div>
         <button
           type="submit"
           disabled={!canSubmit}
           data-testid="keyword-submit"
-          className="rounded-md border border-border bg-bg-card px-4 py-2 text-sm font-medium text-fg hover:bg-bg-subtle disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md border border-border bg-bg-card px-4 py-2 font-medium text-fg text-sm hover:bg-bg-subtle disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isLoading ? "검색 중…" : "검색"}
         </button>
       </form>
 
-      <p className="font-mono text-xs text-fg-subtle">
+      <p className="font-mono text-fg-subtle text-xs">
         2–100자 · Enter 로 제출 · 최근 30일 이내 업로드만 노출
       </p>
     </section>

--- a/frontend/src/components/VideoListView.tsx
+++ b/frontend/src/components/VideoListView.tsx
@@ -1,8 +1,13 @@
+import { EmptyState } from "@/components/EmptyState";
 import { VideoCard } from "@/components/VideoCard";
 import { useAppStore } from "@/store/useAppStore";
 
 export function VideoListView() {
   const { keyword, videos, selectedVideoId, selectVideo, reset } = useAppStore();
+
+  if (videos.length === 0) {
+    return <EmptyState keyword={keyword} onRetry={reset} />;
+  }
 
   return (
     <section className="mx-auto w-full max-w-3xl space-y-6">
@@ -36,7 +41,7 @@ export function VideoListView() {
       </ul>
 
       <p className="font-mono text-[11px] text-fg-subtle">
-        영상을 하나 선택하면 다음 단계(분석)로 진행됩니다. (#12 에서 구현)
+        영상을 하나 선택하면 다음 단계(분석)로 진행됩니다.
       </p>
     </section>
   );

--- a/frontend/tests/EmptyState.test.tsx
+++ b/frontend/tests/EmptyState.test.tsx
@@ -1,0 +1,18 @@
+import { EmptyState } from "@/components/EmptyState";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("EmptyState", () => {
+  it("renders the keyword in the message", () => {
+    render(<EmptyState keyword="zzzxxxyyy" onRetry={() => {}} />);
+    expect(screen.getByText(/검색 결과가 없어요/)).toBeInTheDocument();
+    expect(screen.getByText(/zzzxxxyyy/)).toBeInTheDocument();
+  });
+
+  it("calls onRetry when the retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(<EmptyState keyword="zzz" onRetry={onRetry} />);
+    fireEvent.click(screen.getByTestId("empty-state-retry"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #14

- 검색 0건: 4xx에서 200+empty 로 변경 → EmptyState 카드로 UX 전환
- 네트워크/5xx: 502 YOUTUBE_API_ERROR + retryable=true 유지 → ErrorBanner + 재시도

### Backend
- `api/search.py`: 404/NO_RESULTS 제거
- `tests/test_search_route.py`: 200+빈 배열 + 502 HTTPStatusError / ConnectError

### Frontend
- `EmptyState` 컴포넌트 (키워드 echo + retry CTA)
- `VideoListView`: videos.length===0 → EmptyState
- `KeywordInputView`: 빈 응답도 success 로 처리
- `EmptyState.test.tsx`: 키워드 표시 + retry 핸들러