### PR TITLE
feat(#15): US-02 edge cases — transcript warning + LLM retry

### DIFF
--- a/backend/app/adapters/claude_adapter.py
+++ b/backend/app/adapters/claude_adapter.py
@@ -2,17 +2,28 @@
 
 Applies prompt caching to the system prompt so repeated calls within the
 5-minute ephemeral window pay ~10% of the input-token rate.
+
+Resilience: a single automatic retry on transient errors (timeout / 5xx).
+The second failure bubbles up so the route handler can surface a rose-
+colored LogStream entry.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 
 from app.ports.llm_provider import LLMProvider, ReportSection
 
+_LOG = logging.getLogger(__name__)
+
+_CLIENT_TIMEOUT_SECONDS = 30.0
+_RETRY_BACKOFF_SECONDS = 2.0
+
 
 class ClaudeAdapter(LLMProvider):
-    """Claude provider with prompt caching."""
+    """Claude provider with prompt caching + one-shot retry."""
 
     name = "claude"
 
@@ -22,17 +33,19 @@ class ClaudeAdapter(LLMProvider):
         *,
         model: str = "claude-sonnet-4-6",
         max_tokens: int = 4096,
+        timeout: float = _CLIENT_TIMEOUT_SECONDS,
     ) -> None:
         self._api_key = api_key
         self._model = model
         self._max_tokens = max_tokens
+        self._timeout = timeout
         self._client = None
 
     def _get_client(self):  # type: ignore[no-untyped-def]
         if self._client is None:
             import anthropic
 
-            self._client = anthropic.AsyncAnthropic(api_key=self._api_key)
+            self._client = anthropic.AsyncAnthropic(api_key=self._api_key, timeout=self._timeout)
         return self._client
 
     async def structure(
@@ -42,6 +55,20 @@ class ClaudeAdapter(LLMProvider):
         transcript: str,
         system_prompt: str,
     ) -> ReportSection:
+        try:
+            return await self._call_once(
+                title=title, transcript=transcript, system_prompt=system_prompt
+            )
+        except Exception as first_err:  # noqa: BLE001 — SDK exceptions vary by version
+            if not _is_retryable(first_err):
+                raise
+            _LOG.warning("Claude call failed once (%s); retrying", type(first_err).__name__)
+            await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+            return await self._call_once(
+                title=title, transcript=transcript, system_prompt=system_prompt
+            )
+
+    async def _call_once(self, *, title: str, transcript: str, system_prompt: str) -> ReportSection:
         client = self._get_client()
         message = await client.messages.create(
             model=self._model,
@@ -73,6 +100,21 @@ class ClaudeAdapter(LLMProvider):
             lecture_tips=str(payload.get("lectureTips", "")),
             references=list(payload.get("references", [])),
         )
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Return True for transient errors worth a single retry."""
+    if isinstance(exc, TimeoutError):
+        return True
+    name = type(exc).__name__
+    # anthropic SDK lifts HTTP problems into its own classes; match by name so
+    # we don't have to import the SDK just for isinstance checks in hot code.
+    return name in {
+        "APITimeoutError",
+        "APIConnectionError",
+        "InternalServerError",
+        "RateLimitError",
+    }
 
 
 def _parse_json_payload(text: str) -> dict:

--- a/backend/tests/test_claude_adapter.py
+++ b/backend/tests/test_claude_adapter.py
@@ -1,13 +1,13 @@
-"""Unit tests for ClaudeAdapter — only the parsing helper is exercised here,
-since the real network call is mocked at the integration layer."""
+"""Unit tests for ClaudeAdapter — parsing helper + retry policy."""
 
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.adapters.claude_adapter import _parse_json_payload
+from app.adapters.claude_adapter import ClaudeAdapter, _is_retryable, _parse_json_payload
 
 
 def test_parse_json_payload_strips_code_fence() -> None:
@@ -26,3 +26,100 @@ def test_parse_json_payload_plain_object() -> None:
 def test_parse_json_payload_rejects_garbage() -> None:
     with pytest.raises(json.JSONDecodeError):
         _parse_json_payload("not json")
+
+
+def test_is_retryable_timeout_is_retryable() -> None:
+    assert _is_retryable(TimeoutError("slow")) is True
+
+
+def test_is_retryable_value_error_not_retryable() -> None:
+    assert _is_retryable(ValueError("nope")) is False
+
+
+def test_is_retryable_matches_anthropic_class_names_by_name() -> None:
+    class APITimeoutError(Exception):
+        pass
+
+    class RateLimitError(Exception):
+        pass
+
+    class RandomError(Exception):
+        pass
+
+    assert _is_retryable(APITimeoutError()) is True
+    assert _is_retryable(RateLimitError()) is True
+    assert _is_retryable(RandomError()) is False
+
+
+@pytest.mark.anyio
+async def test_structure_retries_once_then_succeeds() -> None:
+    adapter = ClaudeAdapter(api_key="dummy", timeout=1.0)
+    calls = {"n": 0}
+    good = AsyncMock(
+        return_value=type(
+            "Fake",
+            (),
+            {
+                "content": [
+                    type(
+                        "Block",
+                        (),
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "overview": "ok",
+                                    "coreConcepts": ["c"],
+                                    "detailedContent": "",
+                                    "lectureTips": "",
+                                    "references": [],
+                                }
+                            ),
+                        },
+                    )
+                ]
+            },
+        )(),
+    )
+
+    async def flaky(*args, **kwargs):  # noqa: ARG001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("first shot")
+        return await good()
+
+    # Patch _call_once's client.messages.create by patching _get_client to
+    # return an object whose messages.create is our flaky coroutine.
+    fake_client = type(
+        "Client",
+        (),
+        {"messages": type("M", (), {"create": flaky})()},
+    )()
+    with patch.object(adapter, "_get_client", return_value=fake_client):
+        result = await adapter.structure(title="t", transcript="x", system_prompt="s")
+    assert calls["n"] == 2
+    assert result.overview == "ok"
+
+
+@pytest.mark.anyio
+async def test_structure_raises_after_second_failure() -> None:
+    adapter = ClaudeAdapter(api_key="dummy", timeout=1.0)
+
+    async def always_fail(*args, **kwargs):  # noqa: ARG001
+        raise TimeoutError("still slow")
+
+    fake_client = type(
+        "Client",
+        (),
+        {"messages": type("M", (), {"create": always_fail})()},
+    )()
+    with (
+        patch.object(adapter, "_get_client", return_value=fake_client),
+        pytest.raises(TimeoutError),
+    ):
+        await adapter.structure(title="t", transcript="x", system_prompt="s")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -1,30 +1,56 @@
 import type { ApiError } from "@/lib/types";
-import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AlertCircle, AlertTriangle } from "lucide-react";
 
 interface ErrorBannerProps {
   error: ApiError;
   onRetry?: () => void;
 }
 
+/**
+ * Error / warning banner. The variant is inferred from the error code so
+ * that "user-recoverable" outcomes (e.g. NO_TRANSCRIPT) read as a warning
+ * rather than a red-alert failure.
+ */
+function isWarning(code: string): boolean {
+  return code === "NO_TRANSCRIPT";
+}
+
 export function ErrorBanner({ error, onRetry }: ErrorBannerProps) {
+  const warn = isWarning(error.code);
+  const Icon = warn ? AlertTriangle : AlertCircle;
+
   return (
     <div
       role="alert"
       data-testid="error-banner"
-      className="mx-auto flex w-full max-w-2xl items-start gap-3 rounded-md border border-error/40 bg-error/10 p-4"
+      data-variant={warn ? "warning" : "error"}
+      className={cn(
+        "mx-auto flex w-full max-w-2xl items-start gap-3 rounded-md border p-4",
+        warn ? "border-warn/40 bg-warn/10" : "border-error/40 bg-error/10",
+      )}
     >
-      <AlertCircle size={18} className="mt-0.5 shrink-0 text-error" aria-hidden />
+      <Icon
+        size={18}
+        className={cn("mt-0.5 shrink-0", warn ? "text-warn" : "text-error")}
+        aria-hidden
+      />
       <div className="flex-1 text-sm">
-        <p className="font-medium text-error">{error.message}</p>
+        <p className={cn("font-medium", warn ? "text-warn" : "text-error")}>{error.message}</p>
         <p className="mt-1 font-mono text-[11px] text-fg-muted">code: {error.code}</p>
       </div>
-      {onRetry && error.retryable ? (
+      {onRetry && (warn || error.retryable) ? (
         <button
           type="button"
           onClick={onRetry}
-          className="rounded border border-error/40 px-3 py-1 text-xs text-error hover:bg-error/20"
+          className={cn(
+            "rounded border px-3 py-1 text-xs",
+            warn
+              ? "border-warn/40 text-warn hover:bg-warn/20"
+              : "border-error/40 text-error hover:bg-error/20",
+          )}
         >
-          다시 시도
+          {warn ? "다른 영상 선택" : "다시 시도"}
         </button>
       ) : null}
     </div>

--- a/frontend/tests/ErrorBanner.test.tsx
+++ b/frontend/tests/ErrorBanner.test.tsx
@@ -1,0 +1,40 @@
+import { ErrorBanner } from "@/components/ErrorBanner";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("ErrorBanner", () => {
+  it("renders as a warning for NO_TRANSCRIPT and shows the friendly CTA", () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorBanner
+        error={{ code: "NO_TRANSCRIPT", message: "자막이 없어요.", retryable: false }}
+        onRetry={onRetry}
+      />,
+    );
+    const banner = screen.getByTestId("error-banner");
+    expect(banner.getAttribute("data-variant")).toBe("warning");
+
+    const cta = screen.getByRole("button", { name: "다른 영상 선택" });
+    fireEvent.click(cta);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders as an error for retryable network failures", () => {
+    render(
+      <ErrorBanner
+        error={{ code: "YOUTUBE_API_ERROR", message: "접속 불가.", retryable: true }}
+        onRetry={() => {}}
+      />,
+    );
+    const banner = screen.getByTestId("error-banner");
+    expect(banner.getAttribute("data-variant")).toBe("error");
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
+  });
+
+  it("hides the retry button when the error is neither a warning nor retryable", () => {
+    render(
+      <ErrorBanner error={{ code: "SAVE_FAILED", message: "저장 실패.", retryable: false }} />,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #15

- Backend: ClaudeAdapter 30s timeout + 1회 자동 retry (TimeoutError/APITimeoutError 등)
- Frontend: NO_TRANSCRIPT → warning variant + "다른 영상 선택" CTA
- 테스트: retry 2회 성공, 재실패 bubble, warning/error variant 분기