### PR TITLE
test(#16): expand Playwright E2E — success/no-results/no-transcript

### DIFF
--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -1,0 +1,54 @@
+/**
+ * Response fixtures for Playwright route mocks.
+ *
+ * We intercept /api/* in the browser rather than hitting the real services
+ * so the E2E suite stays deterministic, zero-cost, and <5 min.
+ */
+
+export const FIVE_VIDEOS = {
+  ok: true,
+  data: {
+    videos: Array.from({ length: 5 }, (_, i) => ({
+      videoId: `fxvid${i}`,
+      title: `Fixture Video ${i} — LLM Deep Dive`,
+      url: `https://www.youtube.com/watch?v=fxvid${i}`,
+      publishedAt: "2026-04-15T10:00:00Z",
+      channelTitle: `Engineering Talks ${i}`,
+    })),
+  },
+};
+
+export const ZERO_VIDEOS = {
+  ok: true,
+  data: { videos: [] },
+};
+
+export const NO_TRANSCRIPT_ERROR = {
+  detail: {
+    code: "NO_TRANSCRIPT",
+    message: "해당 영상은 자막을 제공하지 않아 분석할 수 없어요. 다른 영상을 선택해주세요.",
+    retryable: false,
+  },
+};
+
+export const ANALYZE_OK = {
+  ok: true,
+  data: {
+    videoId: "fxvid0",
+    title: "Fixture Video 0 — LLM Deep Dive",
+    sourceUrl: "https://www.youtube.com/watch?v=fxvid0",
+    publishedAt: "2026-04-15T10:00:00Z",
+    generatedAt: "2026-04-24T08:00:00Z",
+    llmProvider: "claude",
+    sections: {
+      overview: "개요 문장.",
+      coreConcepts: ["개념 A", "개념 B"],
+      detailedContent: "상세 본문 Markdown.",
+      lectureTips: "강의 팁.",
+      references: ["https://example.com/ref"],
+    },
+    markdown:
+      "# Fixture Video 0 — LLM Deep Dive\n\n## 개요\n\n개요 문장.\n\n## 핵심 개념\n\n- 개념 A\n- 개념 B\n",
+    savedPath: "./reports/2026-04-24-fixture-video-0.md",
+  },
+};

--- a/frontend/tests/e2e/no-results.spec.ts
+++ b/frontend/tests/e2e/no-results.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { ZERO_VIDEOS } from "./fixtures";
+
+test("zero results → EmptyState + retry CTA", async ({ page }) => {
+  await page.route("**/api/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ZERO_VIDEOS),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByTestId("keyword-input").fill("zzzxxxyyy");
+  await page.getByTestId("keyword-submit").click();
+
+  const empty = page.getByTestId("empty-state");
+  await expect(empty).toBeVisible();
+  await expect(empty).toContainText("검색 결과가 없어요");
+  await expect(empty).toContainText("zzzxxxyyy");
+
+  // Retry CTA returns the user to the keyword input view
+  await page.getByTestId("empty-state-retry").click();
+  await expect(page.getByTestId("keyword-input")).toBeVisible();
+});

--- a/frontend/tests/e2e/no-transcript.spec.ts
+++ b/frontend/tests/e2e/no-transcript.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { FIVE_VIDEOS, NO_TRANSCRIPT_ERROR } from "./fixtures";
+
+test("video without transcript → warning ErrorBanner + back-to-list CTA", async ({ page }) => {
+  await page.route("**/api/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(FIVE_VIDEOS),
+    });
+  });
+  await page.route("**/api/analyze", async (route) => {
+    await route.fulfill({
+      status: 422,
+      contentType: "application/json",
+      body: JSON.stringify(NO_TRANSCRIPT_ERROR),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByTestId("keyword-input").fill("react");
+  await page.getByTestId("keyword-submit").click();
+  await page.getByTestId("video-card").first().click();
+
+  const banner = page.getByTestId("error-banner");
+  await expect(banner).toBeVisible({ timeout: 15_000 });
+  await expect(banner).toHaveAttribute("data-variant", "warning");
+  await expect(banner).toContainText("자막을 제공하지 않아");
+
+  // "다른 영상 선택" dismisses the banner and keeps the user on the list
+  await page.getByRole("button", { name: "다른 영상 선택" }).click();
+  await expect(page.getByTestId("video-list")).toBeVisible();
+});

--- a/frontend/tests/e2e/search-success.spec.ts
+++ b/frontend/tests/e2e/search-success.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { ANALYZE_OK, FIVE_VIDEOS } from "./fixtures";
+
+test("search → pick → report Happy Path (mocked API)", async ({ page }) => {
+  await page.route("**/api/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(FIVE_VIDEOS),
+    });
+  });
+  await page.route("**/api/analyze", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ANALYZE_OK),
+    });
+  });
+
+  await page.goto("/");
+
+  // Phase 1 — search
+  await page.getByTestId("keyword-input").fill("react");
+  await page.getByTestId("keyword-submit").click();
+
+  // Phase 2 — video list
+  const videoList = page.getByTestId("video-list");
+  await expect(videoList).toBeVisible();
+  const cards = page.getByTestId("video-card");
+  await expect(cards).toHaveCount(5);
+
+  // Phase 3 — pick one
+  await cards.first().click();
+
+  // Phase 4 — report lands (AnalyzingView transitions quickly because /analyze is mocked)
+  const report = page.getByTestId("report-result");
+  await expect(report).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("saved-path")).toContainText("2026-04-24-fixture-video-0.md");
+  await expect(page.getByTestId("markdown-preview")).toContainText("# Fixture Video 0");
+});


### PR DESCRIPTION
Closes #16

Playwright `page.route` mock 으로 결정론적 시나리오 3건 추가. 실제 YouTube/Claude 호출 없음.

- `search-success`: 키워드 → 5 카드 → 선택 → 보고서 렌더
- `no-results`: 빈 배열 → EmptyState + 재시도
- `no-transcript`: 422 → warning 배너 + "다른 영상 선택"

AC: 3건 병렬 5분 이내 (실측 ~30초).