### PR TITLE
feat(#19): Claude token counter + /api/health spend badge

### DIFF
--- a/backend/app/adapters/claude_adapter.py
+++ b/backend/app/adapters/claude_adapter.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 
+from app.observability.token_counter import TokenCounter, get_token_counter
 from app.ports.llm_provider import LLMProvider, ReportSection
 
 _LOG = logging.getLogger(__name__)
@@ -34,12 +35,14 @@ class ClaudeAdapter(LLMProvider):
         model: str = "claude-sonnet-4-6",
         max_tokens: int = 4096,
         timeout: float = _CLIENT_TIMEOUT_SECONDS,
+        counter: TokenCounter | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
         self._max_tokens = max_tokens
         self._timeout = timeout
         self._client = None
+        self._counter = counter if counter is not None else get_token_counter()
 
     def _get_client(self):  # type: ignore[no-untyped-def]
         if self._client is None:
@@ -91,6 +94,15 @@ class ClaudeAdapter(LLMProvider):
         text = "".join(
             block.text for block in message.content if getattr(block, "type", None) == "text"
         ).strip()
+
+        # Record token usage — the response's `usage` object carries the counts.
+        usage = getattr(message, "usage", None)
+        if usage is not None:
+            self._counter.record(
+                input_tokens=int(getattr(usage, "input_tokens", 0) or 0),
+                output_tokens=int(getattr(usage, "output_tokens", 0) or 0),
+                cache_read_tokens=int(getattr(usage, "cache_read_input_tokens", 0) or 0),
+            )
 
         payload = _parse_json_payload(text)
         return ReportSection(

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -2,20 +2,29 @@ from fastapi import APIRouter, Depends
 
 from app import __version__
 from app.config import Settings, get_settings
+from app.observability.token_counter import TokenCounter, get_token_counter
 from app.schemas import HealthData, HealthResponse
 
 router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health", response_model=HealthResponse)
-def health(settings: Settings = Depends(get_settings)) -> HealthResponse:
-    """Return a minimal status envelope so the frontend dashboard can
-    prove end-to-end connectivity without invoking any external API."""
+def health(
+    settings: Settings = Depends(get_settings),
+    counter: TokenCounter = Depends(get_token_counter),
+) -> HealthResponse:
+    """Return a minimal status envelope + cumulative Claude token usage
+    so the dashboard can display an approximate spend since process start."""
+    usage = counter.snapshot()
     return HealthResponse(
         ok=True,
         data=HealthData(
             status="up",
             llmProvider=settings.llm_provider,
             version=__version__,
+            tokensInput=usage.input_tokens,
+            tokensOutput=usage.output_tokens,
+            tokensCacheRead=usage.cache_read_tokens,
+            estimatedCostUsd=usage.estimated_cost_usd(),
         ),
     )

--- a/backend/app/observability/token_counter.py
+++ b/backend/app/observability/token_counter.py
@@ -1,0 +1,74 @@
+"""Process-local running total of Claude token usage.
+
+Deliberately minimal: no file persistence (restarts reset to zero), no
+background flush, no per-request storage. The goal is "the professor can
+see roughly how much the day's demo cost" on the `/api/health` response
+without standing up a metrics backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+
+# Claude Sonnet 4.6 public pricing (2026-04)
+# https://www.anthropic.com/pricing
+_COST_INPUT_PER_MTOK = 3.0
+_COST_OUTPUT_PER_MTOK = 15.0
+_COST_CACHE_READ_PER_MTOK = 0.30  # 10% of input rate
+
+
+@dataclass
+class TokenUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+
+    def estimated_cost_usd(self) -> float:
+        return round(
+            (self.input_tokens / 1_000_000.0) * _COST_INPUT_PER_MTOK
+            + (self.output_tokens / 1_000_000.0) * _COST_OUTPUT_PER_MTOK
+            + (self.cache_read_tokens / 1_000_000.0) * _COST_CACHE_READ_PER_MTOK,
+            6,
+        )
+
+
+class TokenCounter:
+    """Thread-safe in-memory cumulative counter — singleton per process."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._usage = TokenUsage()
+
+    def record(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_tokens: int = 0,
+    ) -> None:
+        with self._lock:
+            self._usage.input_tokens += max(0, input_tokens)
+            self._usage.output_tokens += max(0, output_tokens)
+            self._usage.cache_read_tokens += max(0, cache_read_tokens)
+
+    def snapshot(self) -> TokenUsage:
+        with self._lock:
+            return TokenUsage(
+                input_tokens=self._usage.input_tokens,
+                output_tokens=self._usage.output_tokens,
+                cache_read_tokens=self._usage.cache_read_tokens,
+            )
+
+    def reset(self) -> None:
+        with self._lock:
+            self._usage = TokenUsage()
+
+
+# Process-global singleton — instance identity matters so the same counter
+# is shared between the adapter and the health route.
+_counter = TokenCounter()
+
+
+def get_token_counter() -> TokenCounter:
+    return _counter

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -17,6 +17,11 @@ class HealthData(BaseModel):
     status: Literal["up", "degraded", "down"] = "up"
     llm_provider: str = Field(..., alias="llmProvider")
     version: str
+    # Observability — cumulative since process start (resets on restart)
+    tokens_input: int = Field(default=0, alias="tokensInput")
+    tokens_output: int = Field(default=0, alias="tokensOutput")
+    tokens_cache_read: int = Field(default=0, alias="tokensCacheRead")
+    estimated_cost_usd: float = Field(default=0.0, alias="estimatedCostUsd")
 
     model_config = {"populate_by_name": True}
 

--- a/backend/tests/test_token_counter.py
+++ b/backend/tests/test_token_counter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.observability.token_counter import TokenCounter, get_token_counter
+
+
+def test_record_accumulates_across_calls() -> None:
+    counter = TokenCounter()
+    counter.record(input_tokens=100, output_tokens=50)
+    counter.record(input_tokens=200, output_tokens=150, cache_read_tokens=80)
+
+    snap = counter.snapshot()
+    assert snap.input_tokens == 300
+    assert snap.output_tokens == 200
+    assert snap.cache_read_tokens == 80
+
+
+def test_cost_calculation_matches_public_pricing() -> None:
+    counter = TokenCounter()
+    # 1M input + 1M output + 1M cache-read = $3 + $15 + $0.30 = $18.30
+    counter.record(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=1_000_000)
+    cost = counter.snapshot().estimated_cost_usd()
+    assert cost == 18.30
+
+
+def test_reset_zeroes_the_counter() -> None:
+    counter = TokenCounter()
+    counter.record(input_tokens=100, output_tokens=50)
+    counter.reset()
+    snap = counter.snapshot()
+    assert snap.input_tokens == 0
+    assert snap.output_tokens == 0
+    assert snap.estimated_cost_usd() == 0.0
+
+
+def test_negative_inputs_are_clamped_to_zero() -> None:
+    counter = TokenCounter()
+    counter.record(input_tokens=-10, output_tokens=-5)
+    snap = counter.snapshot()
+    assert snap.input_tokens == 0
+    assert snap.output_tokens == 0
+
+
+def test_health_endpoint_exposes_counter_snapshot() -> None:
+    counter = TokenCounter()
+    counter.record(input_tokens=1500, output_tokens=600)
+    app.dependency_overrides[get_token_counter] = lambda: counter
+    try:
+        client = TestClient(app)
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["tokensInput"] == 1500
+        assert data["tokensOutput"] == 600
+        assert data["estimatedCostUsd"] > 0
+    finally:
+        app.dependency_overrides.pop(get_token_counter, None)

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -59,6 +59,16 @@ export function Sidebar() {
         {data ? (
           <p className="mt-1 font-mono text-[10px] text-fg-subtle">llm: {data.llmProvider}</p>
         ) : null}
+        {data && (data.estimatedCostUsd ?? 0) > 0 ? (
+          <p
+            className="mt-1 font-mono text-[10px] text-fg-subtle"
+            data-testid="cost-badge"
+            title="Cumulative since process start (resets on restart)"
+          >
+            spend: ${data.estimatedCostUsd?.toFixed(4) ?? "0"} ·{" "}
+            {((data.tokensInput ?? 0) + (data.tokensOutput ?? 0)).toLocaleString()} tok
+          </p>
+        ) : null}
       </footer>
     </aside>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,10 @@ export interface HealthData {
   status: "up" | "degraded" | "down";
   llmProvider: string;
   version: string;
+  tokensInput?: number;
+  tokensOutput?: number;
+  tokensCacheRead?: number;
+  estimatedCostUsd?: number;
 }
 
 interface Envelope<T> {


### PR DESCRIPTION
Closes #19

- `TokenCounter` 싱글톤 (input/output/cache_read, Claude Sonnet 4.6 공시 단가)
- `ClaudeAdapter` 응답의 `usage` 필드 → counter.record
- `/api/health` 에 tokensInput/Output/CacheRead/estimatedCostUsd 노출
- Sidebar Footer "spend: $0.xxxx · N tok" 배지 (0이면 숨김)
- 테스트 5건 (누적, 비용 계산, 리셋, 음수 clamp, /health wire-through)