### PR TITLE
docs(#20): README release polish + CHANGELOG + education notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] — 2026-04-24
+
+프로젝트 초도 릴리즈. SDLC 한 바퀴 전 과정을 강의 자료로 남길 수 있는 **9/20 → 19/20 이슈 완료** 상태의 스냅샷. 프로덕션 배포(#18)는 보안 정책상 수동 작업으로 유보.
+
+### Added — Phase 0 (기반 · CI/CD · Walking Skeleton)
+
+- Monorepo 스캐폴딩: `/frontend` (Vite + React + TS + Tailwind) · `/backend` (FastAPI + uv + Pydantic) — #1
+- GitHub Actions 기본 워크플로 (`lint.yml`, `test.yml`) — #2
+- README 상태 배지 + `CONTRIBUTING.md` + branch-protection 정책 문서 — #3
+- `Dockerfile × 2` + `docker-compose.yml` + nginx SPA 프록시 — #4
+- 스테이징 자동 배포 (`deploy-staging.yml` — runner 내 compose up) — #5
+- Smoke test 스크립트 `scripts/smoke.sh` + emergency teardown — #6
+- `GET /api/health` + React 다크 대시보드 AppShell — #7
+- `Config` + `LLMProvider` Port + Claude/OpenAI/Ollama Adapter 스텁 — #8
+- Playwright E2E smoke 1건 — #9
+- Security 워크플로 (bandit + pip-audit + biome + pnpm audit) — #10
+
+### Added — Phase 1 (Core MVP)
+
+- **US-01**: `POST /api/search` · YouTubeDataAdapter · SearchService + LRU 5분 캐시 · `KeywordInputView` · `VideoCard` · `VideoListView` — #11
+- **US-02**: `POST /api/analyze` · YouTubeTranscriptAdapter · ClaudeAdapter (prompt caching) · `AnalysisPipeline` · `MarkdownRenderer` · `FileRepository` · `ReportResultView` (마크다운 미리보기 + 파일 경로 복사) — #12
+- AnalyzingView 폴리시: `LogStream` (JetBrains Mono, 3색, auto-scroll) + `ProgressBar` (단계별 %) — #13
+
+### Added — Phase 2 (엣지 케이스)
+
+- 검색 0건 → `EmptyState` (200 + 빈 배열 정규화) · 네트워크 오류 → 502 + 재시도 — #14
+- 자막 없음 → ErrorBanner warning 변형 + "다른 영상 선택" CTA · LLM 30s timeout + 자동 1회 재시도 — #15
+
+### Added — Phase 3 (운영화)
+
+- Playwright E2E 3건 확장 (success / no-results / no-transcript, `page.route` mock 기반) — #16
+- WCAG AA 대비율 튜닝 · "/" 전역 단축키 · `@axe-core/playwright` E2E 가드 — #17
+- Claude 토큰 누적 카운터 + `/api/health` 비용 노출 + Sidebar 스펜드 배지 — #19
+- README · CHANGELOG · `docs/education-notes.md` · Provider 교체 실습 가이드 — #20
+
+### Deferred
+
+- **#3 branch protection API** — 보안 정책상 AI 수동 실행 불가. 이슈 #3 에 남긴 1회성 `gh api` 명령을 교수님이 직접 실행하시면 활성화됩니다.
+- **#18 프로덕션 배포** (Fly.io + Vercel + 수동 승인 게이트) — 외부 서비스 유료 계정 + 시크릿 등록이 필요하므로 의도적으로 유보. 스테이징(#5) 레시피를 그대로 옮겨 확장하면 됩니다.
+
+### Stack
+
+| 계층 | 구성 |
+|------|------|
+| Frontend | React 18 · TypeScript 5 · Vite 5 · Tailwind 3 · Biome 1.8 · Zustand · lucide-react |
+| Backend | FastAPI 0.111 · Uvicorn · Pydantic 2.7 · httpx · uv 0.4 · ruff |
+| LLM | `LLMProvider` Port → ClaudeAdapter (기본, Sonnet 4.6) · OpenAI/Ollama 학생 실습 스텁 |
+| External | YouTube Data API v3 · youtube-transcript-api · anthropic SDK |
+| Storage | 로컬 FS (`./reports/*.md`) — DB 없음 |
+| CI/CD | GitHub Actions × 5 (lint · test · e2e · security · deploy-staging) |
+| Test | Vitest + Testing Library · Playwright + axe-core · pytest + respx |
+
+### SDLC 산출물
+
+- [`prd.md`](./prd.md), [`techspec.md`](./techspec.md), [`issues-vertical.md`](./issues-vertical.md)
+- GitHub Issues #1~#20 · Project #20 "TechReport Sprint 1"
+
+[0.1.0]: https://github.com/ischung/techreport-from-utube/releases/tag/v0.1.0
+[Unreleased]: https://github.com/ischung/techreport-from-utube/compare/v0.1.0...HEAD

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![lint](https://github.com/ischung/techreport-from-utube/actions/workflows/lint.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/lint.yml)
 [![test](https://github.com/ischung/techreport-from-utube/actions/workflows/test.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/test.yml)
+[![e2e](https://github.com/ischung/techreport-from-utube/actions/workflows/e2e.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/e2e.yml)
+[![security](https://github.com/ischung/techreport-from-utube/actions/workflows/security.yml/badge.svg)](https://github.com/ischung/techreport-from-utube/actions/workflows/security.yml)
 
 키워드 한 줄로 최근 1개월 YouTube 영상 5개를 찾아, 선택한 1편을 분석해 **한국어 기술보고서(마크다운)** 를 자동 생성하는 로컬 웹 대시보드입니다. 한성대 소프트웨어공학과 강의 데모 및 SDLC 실습 교재로 사용됩니다.
 
@@ -10,10 +12,13 @@
 ```bash
 git clone https://github.com/ischung/techreport-from-utube.git && cd techreport-from-utube
 cp .env.example .env          # ANTHROPIC_API_KEY · YOUTUBE_API_KEY 채우기
-pnpm --dir frontend install && uv --directory backend sync   # 의존성 설치
+docker compose up -d          # frontend:80 + backend:8000 동시 기동
+open http://localhost          # 브라우저에서 대시보드 오픈
 ```
 
-그다음:
+API 키 없이 구조만 확인하고 싶으면 `.env` 를 비워두세요. `/api/health` 는 그대로 응답합니다 (실제 검색·분석만 실패).
+
+### 또는 로컬 dev 모드로
 
 ```bash
 # 두 개의 터미널에서 각각
@@ -21,51 +26,164 @@ uv --directory backend run uvicorn app.main:app --reload     # http://localhost:
 pnpm --dir frontend dev                                      # http://localhost:5173
 ```
 
+---
+
 ## Monorepo 구조
 
 ```
 .
-├── frontend/            # React 18 + TypeScript + Vite + Tailwind + shadcn/ui
-│   ├── src/             # UI 컴포넌트 · 상태 · API 클라이언트
-│   └── tests/           # Vitest 단위 · Playwright E2E
-├── backend/             # FastAPI + uv + Pydantic + anthropic SDK
-│   ├── app/             # Routes · Services · Pipeline · Ports · Adapters
-│   └── tests/           # pytest
-├── reports/             # 생성된 기술보고서(.md) — git 제외
-├── prd.md               # 제품 요구 문서 (PRD)
-├── techspec.md          # 기술 명세 (Port-Adapter + Pipeline)
-├── issues-vertical.md   # 이슈 분할 (Vertical Slice + CI/CD-first)
-└── .pre-commit-config.yaml
+├── frontend/                    # React 18 + TypeScript + Vite + Tailwind
+│   ├── src/                     # UI 컴포넌트 · Zustand 스토어 · API 클라이언트
+│   └── tests/                   # Vitest 단위 · Playwright E2E + axe-core
+├── backend/                     # FastAPI + uv + Pydantic + anthropic SDK
+│   ├── app/
+│   │   ├── api/                 # Routes (health · search · analyze)
+│   │   ├── services/            # SearchService (LRU cache)
+│   │   ├── pipeline/            # Retrieval → Analysis → Rendering → Save
+│   │   ├── ports/               # LLMProvider · YouTubeSearchPort · TranscriptPort
+│   │   ├── adapters/            # Claude / OpenAI / Ollama / YouTube / Transcript
+│   │   ├── repository/          # FileRepository (./reports/*.md 저장)
+│   │   └── observability/       # TokenCounter (누적 사용량 + 비용)
+│   └── tests/                   # pytest
+├── .github/workflows/           # lint · test · e2e · deploy-staging · security
+├── docs/                        # 강의용 교육 노트
+├── scripts/smoke.sh             # compose up 후 상태 probe
+├── reports/                     # 생성된 기술보고서(.md) — git 제외
+├── prd.md · techspec.md · issues-vertical.md  # SDLC 산출물
+├── CHANGELOG.md                 # 릴리즈 노트
+├── CLAUDE.md                    # Claude Code 작업 규칙
+└── docker-compose.yml · Dockerfile × 2 · .pre-commit-config.yaml
 ```
+
+---
 
 ## 아키텍처 한눈에
 
 ```mermaid
 graph LR
   U[교수/사용자] --> FE[React Dashboard SPA]
-  FE -->|/api/search · /api/analyze| BE[FastAPI Backend]
-  BE -->|search| YT[YouTube Data API v3]
+  FE -->|/api/search · /api/analyze · /api/health| BE[FastAPI Backend]
+  BE -->|search.list| YT[YouTube Data API v3]
   BE -->|transcript| YTS[youtube-transcript-api]
   BE -->|structure| LLM[Claude Sonnet 4.6]
   BE -->|write *.md| FS[(./reports)]
+  BE -->|tokens + cost| OB[TokenCounter]
 ```
 
-`LLMProvider` 는 **Port-Adapter 패턴**으로 구현되어 `.env` 의 `LLM_PROVIDER` 값 한 줄로 `claude` / `openai` / `ollama` 를 교체할 수 있습니다. Clean Architecture 의존성 역전 원칙(DIP)을 실물로 관찰할 수 있는 강의 실습 소재입니다.
+### 분석 파이프라인 (Retrieval → Analysis → Rendering → Save)
+
+```mermaid
+sequenceDiagram
+  participant FE as Dashboard
+  participant API as /api/analyze
+  participant TS as TranscriptPort
+  participant LLM as LLMProvider
+  participant MD as MarkdownRenderer
+  participant FR as FileRepository
+
+  FE->>API: POST { videoId, title, url }
+  API->>TS: fetch(videoId)
+  TS-->>API: 자막 텍스트
+  API->>LLM: structure(title, transcript, system_prompt)
+  Note right of LLM: cache_control: ephemeral<br/>30s timeout + 1회 retry
+  LLM-->>API: ReportSection JSON
+  API->>MD: render(sections)
+  MD-->>API: Markdown 전문
+  API->>FR: save(markdown)
+  FR-->>API: ./reports/YYYY-MM-DD-slug.md
+  API-->>FE: AnalysisReport (markdown + savedPath)
+```
+
+---
+
+## Provider 교체 실습 (학생 과제)
+
+`LLMProvider` 는 **Port-Adapter 패턴**으로 구현되어 `.env` 의 `LLM_PROVIDER` 값 한 줄로 `claude` (기본) · `openai` · `ollama` 를 교체할 수 있습니다. 이것은 **Clean Architecture 의 의존성 역전 원칙(DIP)** 을 실물로 관찰할 수 있는 강의 실습 소재입니다.
+
+### 실습 절차 — OpenAI 어댑터 완성하기
+
+1. **`.env` 수정**:
+   ```bash
+   LLM_PROVIDER=openai
+   OPENAI_API_KEY=sk-...
+   ```
+
+2. **[`backend/app/adapters/openai_adapter.py`](./backend/app/adapters/openai_adapter.py) 의 3개 TODO 를 채웁니다**:
+   - TODO 1: `openai.AsyncOpenAI` 클라이언트 생성
+   - TODO 2: `chat.completions.create` 호출 (system + user, `response_format={"type": "json_object"}`)
+   - TODO 3: 응답 JSON 을 `ReportSection` 으로 매핑
+
+3. **검증**: `docker compose restart backend && open http://localhost` — 코드는 한 줄도 건드리지 않았는데 provider가 바뀝니다. `/api/health` 응답의 `llmProvider` 필드가 `"openai"` 로 바뀌었는지 확인.
+
+4. **토론 질문**: 이 구조에서 `AnalysisPipeline` 은 OpenAI를 알까요? `anthropic` SDK 와 `openai` SDK 는 서로의 존재를 알까요? 이것이 **DIP(Dependency Inversion Principle)** 의 핵심입니다.
+
+### Ollama (로컬 무료 LLM) 실습
+
+1. `brew install ollama && ollama serve &`
+2. `ollama pull qwen2.5` (또는 llama3.1, exaone 등)
+3. `.env` 에서 `LLM_PROVIDER=ollama`
+4. [`backend/app/adapters/ollama_adapter.py`](./backend/app/adapters/ollama_adapter.py) 의 TODO 채우기
+5. 네트워크·비용 없이 완전 오프라인 데모 가능
+
+---
+
+## 비용 관리
+
+### 실제 호출 비용 (Claude Sonnet 4.6, 2026-04 기준)
+
+| 단가 | $3 / MTok (input) | $15 / MTok (output) | $0.30 / MTok (cache read) |
+
+**10~30분 영상 1편 분석 실측**:
+- Input: ~7,000 tok (프롬프트 캐시 적용 시 중복 6,000 tok 은 10% 단가로)
+- Output: ~3,000 tok
+- **약 $0.05 / 편** (월 100편 = 약 $5)
+
+### 런타임 확인
+
+사이드바 Footer 의 `spend: $0.xxxx · N,NNN tok` 배지에 프로세스 누적 사용량이 표시됩니다. `/api/health` 응답에서도 확인 가능:
+
+```bash
+curl -s http://localhost:8000/api/health | jq .data
+# {
+#   "status": "up",
+#   "llmProvider": "claude",
+#   "tokensInput": 7234,
+#   "tokensOutput": 2841,
+#   "estimatedCostUsd": 0.0643
+# }
+```
+
+> 프로세스 재기동 시 0으로 초기화됩니다 (학기 전체 누적이 필요하면 v1.1 에서 SQLite 지속 저장 추가 예정).
+
+---
 
 ## 개발 가이드
 
-- **린트**: `pnpm --dir frontend lint` · `cd backend && ruff check .`
-- **테스트**: `pnpm --dir frontend test` · `cd backend && pytest`
-- **E2E**: `pnpm --dir frontend test:e2e`
-- **pre-commit 설치**: `pipx install pre-commit && pre-commit install`
+| 작업 | 명령 |
+|------|------|
+| 린트 | `pnpm --dir frontend lint` · `cd backend && ruff check .` |
+| 포맷 | `pnpm --dir frontend format` · `cd backend && ruff format .` |
+| 단위 테스트 | `pnpm --dir frontend test` · `cd backend && pytest` |
+| E2E | `pnpm --dir frontend test:e2e` (compose 스택 필요) |
+| 타입체크 | `pnpm --dir frontend typecheck` |
+| 보안 스캔 | CI에서 자동 (bandit + pip-audit + biome + pnpm audit) |
+| pre-commit | `pipx install pre-commit && pre-commit install` |
+
+---
 
 ## 문서
 
 | 파일 | 단계 | 설명 |
 |------|------|------|
 | [`prd.md`](./prd.md) | Phase 1 | 제품 요구사항 (What/Why) |
-| [`techspec.md`](./techspec.md) | Phase 2 | 기술 명세 (How) |
+| [`techspec.md`](./techspec.md) | Phase 2 | 기술 명세 (How) — Port-Adapter + Pipeline |
 | [`issues-vertical.md`](./issues-vertical.md) | Phase 3 | 이슈 분할 (20개 CI-1~CI-20) |
+| [`docs/education-notes.md`](./docs/education-notes.md) | 강의 | DIP · Hexagonal · Walking Skeleton 핵심 정리 |
+| [`CHANGELOG.md`](./CHANGELOG.md) | — | 릴리즈 노트 |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | — | 브랜치 · 커밋 · PR 규칙 |
+| [`CLAUDE.md`](./CLAUDE.md) | — | Claude Code 작업 규칙 |
+
+---
 
 ## 라이선스
 

--- a/docs/education-notes.md
+++ b/docs/education-notes.md
@@ -1,0 +1,159 @@
+# 강의용 교육 노트
+
+이 저장소는 한성대 소프트웨어공학 강의의 **SDLC 전 과정 교재**로 만들어졌습니다. 학생들이 실물 코드를 짚으면서 이론과 연결할 수 있도록 핵심 개념별 "어디를 보라"를 정리합니다.
+
+---
+
+## 1. 의존성 역전 원칙 (DIP)
+
+> "고수준 모듈은 저수준 모듈에 의존해서는 안 된다. 둘 다 추상(abstraction)에 의존해야 한다." — Robert C. Martin
+
+### 어디서 관찰하나
+
+| 추상 (Port) | 구현 (Adapter) | 소비자 |
+|---|---|---|
+| [`app/ports/llm_provider.py`](../backend/app/ports/llm_provider.py) | [`claude_adapter.py`](../backend/app/adapters/claude_adapter.py), [`openai_adapter.py`](../backend/app/adapters/openai_adapter.py), [`ollama_adapter.py`](../backend/app/adapters/ollama_adapter.py) | [`app/pipeline/analysis_pipeline.py`](../backend/app/pipeline/analysis_pipeline.py) |
+| [`app/ports/youtube_search_port.py`](../backend/app/ports/youtube_search_port.py) | [`youtube_data_adapter.py`](../backend/app/adapters/youtube_data_adapter.py) | [`app/services/search_service.py`](../backend/app/services/search_service.py) |
+| [`app/ports/transcript_port.py`](../backend/app/ports/transcript_port.py) | [`youtube_transcript_adapter.py`](../backend/app/adapters/youtube_transcript_adapter.py) | `analysis_pipeline.py` |
+
+### 실험
+
+1. `grep -r "import anthropic" backend/app/pipeline/` — **0건**
+2. `grep -r "import anthropic" backend/app/services/` — **0건**
+3. `grep -r "import anthropic" backend/app/adapters/` — **1건** (claude_adapter만)
+
+→ Pipeline 과 Services 는 Claude SDK 의 존재를 모릅니다. `LLMProvider` 계약만 보면 충분합니다. 이것이 **의존성 역전**입니다.
+
+---
+
+## 2. Hexagonal (Ports & Adapters) 아키텍처
+
+### 두 경계선
+
+```
+                      ┌─────────────────────────────────┐
+  Driving side        │         Application             │     Driven side
+  (Primary actors)    │         (pure business)         │    (secondary actors)
+  ────────────►       │                                 │    ◄────────────
+                      │     Services · Pipelines        │
+  HTTP request        │                                 │     YouTube API
+  (FastAPI routes) ──►│  depends only on Ports          │───► Anthropic API
+                      │                                 │     File system
+                      └─────────────────────────────────┘
+                              ↑                 ↑
+                              │                 │
+                         Ports (추상)       Ports (추상)
+                              │                 │
+                              ↓                 ↓
+                         Routes            Adapters
+                       (Driving)         (Driven — 실제 I/O)
+```
+
+### 이 저장소에서
+
+- **Driving side (HTTP 입구)**: `app/api/*.py` — `/api/search`, `/api/analyze`, `/api/health`
+- **Application core**: `app/services/`, `app/pipeline/` — 외부 I/O 에 대해 무지(無知)한 비즈니스 흐름
+- **Driven side (I/O 출구)**: `app/adapters/` — 실제 네트워크 / 파일 I/O 를 수행하는 구현체
+- **계약선(Ports)**: `app/ports/` — 어느 쪽도 서로를 직접 부르지 않고 이 인터페이스만 참조
+
+### 교체 실험
+
+README의 "Provider 교체 실습" 섹션을 따라 `LLM_PROVIDER=openai` 로 바꾸면 **Adapter 한 파일만** 교체되고 Application core 는 재컴파일조차 하지 않습니다.
+
+---
+
+## 3. Walking Skeleton (Alistair Cockburn)
+
+> "End-to-End 로 최소 동작하는 최초의 베이스라인. 여기 위에 기능을 덧붙인다."
+
+### 이 저장소의 Walking Skeleton
+
+**PR #22 + #28** = 초도 Walking Skeleton:
+- 브라우저 열기 (`http://localhost`)
+- React 대시보드가 렌더된다
+- `/api/health` 응답을 받아 사이드바의 상태 도트가 **emerald 로 바뀐다**
+- 위 흐름이 **CI 워크플로 (lint + test + e2e) 모두 초록불** 위에서 반복 가능하다
+
+### 교육 포인트
+
+1. **뼈대 먼저**: #7 에서 "Hello Dashboard" + `/api/health` 만 구현. 이때는 키워드 검색도, LLM 도 없습니다.
+2. **파이프라인 위에 올라타기**: #11 (search) · #12 (analyze) · #13 (logstream) 세 슬라이스가 이 뼈대에 하나씩 얹혀 들어가며 매번 `pnpm test:e2e` 가 초록불로 남습니다.
+3. **Regressions 감지**: #11 에서 `App.tsx` 를 wizard 로 교체했을 때 기존 `App.test.tsx` 가 즉시 실패 → 문제 **수정 전에 발견**. 이것이 Walking Skeleton 의 가치입니다.
+
+---
+
+## 4. CI/CD First (이 프로젝트의 특이점)
+
+보통 "기능 먼저, CI 는 나중에" 순서지만 이 저장소는 `issues-vertical.md` 의 전략에 따라 **반대**로 움직였습니다.
+
+### 실행 순서 (머지 순)
+
+1. `#1` Monorepo 스캐폴딩
+2. `#2` lint + test 워크플로 → **이 시점부터 모든 PR 은 CI green 이어야 머지 가능**
+3. `#3` 보호 규칙 + 배지
+4. `#4~#6` Docker + 스테이징 + smoke
+5. `#7~#9` Walking Skeleton (위 절)
+6. `#10` Security 스캔
+7. `#11~#20` 기능 슬라이스들
+
+### 교육 포인트
+
+- 기능 슬라이스 PR 모두가 **이미 작동하는 CI/CD 고속도로 위에 올라탑니다**. "CI 가 빨간색이라 머지 못 함" 같은 블로커가 발생하면 **코드가 아니라 파이프라인 을 먼저 고친다**는 엔지니어 습관이 자연스럽게 형성됩니다.
+- 실제로 본 저장소의 초창기 CI 실패들은 대부분 **설정 실수** (lockfile 경로 · biome 1.9 vs 1.8 · ruff 포맷 차이) 였습니다. 기능 버그가 아님. 이 경험이 학생에게 "CI 는 약속의 장부"라는 감각을 남깁니다.
+
+---
+
+## 5. Vertical Slice + YAGNI
+
+각 `[Slice]` 이슈는 **UI + API + Adapter + Test** 를 모두 포함합니다. 예) #11 PR 의 diff:
+
+- `frontend/src/components/KeywordInputView.tsx` (UI)
+- `frontend/src/store/useAppStore.ts` (상태)
+- `backend/app/api/search.py` (API)
+- `backend/app/services/search_service.py` (비즈니스)
+- `backend/app/adapters/youtube_data_adapter.py` (I/O)
+- `backend/tests/test_search_route.py`, `test_youtube_adapter.py` (Test)
+
+### YAGNI 의 증거
+
+- DB 가 없습니다. 모든 저장은 `./reports/*.md` 파일. 왜? PRD §7 이 "단일 사용자 로컬 도구" 라고 못박았기 때문.
+- 인증 시스템이 없습니다. 왜? Out-of-Scope.
+- Redis 캐시가 없습니다. 5분 LRU 는 `OrderedDict` 로 충분합니다.
+
+학기 말에 "이제 DB가 필요하다" 는 순간이 오면 그때 붙입니다. **지금 필요 없으면 만들지 않는 것이 YAGNI** 입니다.
+
+---
+
+## 6. 추천 강의 진행 순서
+
+| 주차 | 이론 | 실물 PR |
+|:---:|------|--------|
+| 1 | SDLC 개요 + PRD 작성법 | [`prd.md`](../prd.md) |
+| 2 | TechSpec · 아키텍처 패턴 | [`techspec.md`](../techspec.md) |
+| 3 | 이슈 분할 전략 (Vertical vs Layered) | [`issues-vertical.md`](../issues-vertical.md) |
+| 4 | GitHub Flow + CI 부트스트랩 | PR #22, #23, #24 |
+| 5 | 컨테이너 + 배포 기초 | PR #25, #26, #27 |
+| 6 | Walking Skeleton 철학 | PR #28, #29, #30 |
+| 7 | Security 스캔 + SAST | PR #31 |
+| 8 | Port-Adapter 실습 (US-01) | PR #32 |
+| 9 | 파이프라인 + Prompt Caching | PR #33 |
+| 10 | UX 폴리시 (LogStream) | PR #34 |
+| 11 | 엣지 케이스 + 에러 모델링 | PR #35, #36 |
+| 12 | 자동화 테스트 확장 (E2E mock) | PR #37 |
+| 13 | 접근성 (WCAG AA) | PR #38 |
+| 14 | 관측성 (토큰 · 비용) | PR #39 |
+| 15 | 문서화 + 릴리즈 | PR #40 (this) |
+
+---
+
+## 7. 다음 학기 과제 아이디어 (Out-of-Scope 이슈들)
+
+PRD §1.3 의 Out-of-Scope 리스트는 **학기말 과제 포트폴리오** 로 직결됩니다:
+
+- 썸네일 표시 (`#next-1`)
+- 검색 히스토리 SQLite 영속화 (`#next-2`, `TokenCounter` 도 함께 지속)
+- 여러 영상 비교 보고서 (`#next-3`)
+- 영문 보고서 모드 (`#next-4`)
+- Firebase 등 외부 저장 (`#next-5`)
+
+각 과제는 이미 Hexagonal 경계가 잡혀 있어서 **Adapter 한 개 교체 / Repository 한 개 추가** 로 완성할 수 있습니다.


### PR DESCRIPTION
Closes #20

마지막 자동 진행 이슈. SDLC 한 바퀴를 강의 교재로 완성.

- `README.md`: e2e/security 배지 추가, compose quickstart 전면 배치, Provider 교체 실습 4단계, 비용 관리 섹션
- `CHANGELOG.md`: v0.1.0 스냅샷 (Phase 0~3, #1~#20 전부, deferred #3 · #18 명시)
- `docs/education-notes.md`: DIP · Hexagonal · Walking Skeleton · CI/CD-first · YAGNI 각각을 실제 PR 번호와 파일로 매핑, 15주 강의 진행표