### PR TITLE
fix(#41): 한글 글자 깨짐 수정 — nginx UTF-8 charset + 컨테이너 C.UTF-8 locale

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,9 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 # Install uv (static binary) — pin to a known-good minor for reproducibility
 RUN pip install --no-cache-dir uv==0.4.*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,6 +17,8 @@ COPY . .
 RUN pnpm build
 
 FROM nginx:alpine AS runtime
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Force UTF-8 on all text responses so Korean characters render correctly.
+    # Without this, nginx omits charset from Content-Type and browsers fall back to ISO-8859-1.
+    charset utf-8;
+    charset_types text/html text/css text/xml text/plain application/javascript application/json application/rss+xml;
+
     # SPA fallback — every unknown path returns index.html so client-side router takes over
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

- **nginx** `charset utf-8;` + `charset_types` 추가 → `Content-Type` 헤더에 `charset=utf-8` 강제로 탑재 (주원인 수정)
- **frontend/backend Dockerfile** 모두 `ENV LANG=C.UTF-8 LC_ALL=C.UTF-8` 추가 → 파일 경로·로그·서브프로세스에서 한글 안전 처리
- **수정 파일 3개, +10 -1 lines** (최소 침습)

## Root Cause

nginx 는 기본적으로 `charset` 을 Content-Type 헤더에 부가하지 않습니다. HTML 문서 안의 `<meta charset="UTF-8">` 이 있어도 HTTP 헤더가 우선 권위를 가지므로, 브라우저가 RFC 2616 에 따라 `ISO-8859-1` 로 해석 → UTF-8 한글 3바이트가 각각 별개 문자로 풀리면서 깨짐(mojibake) 발생.

## Verification (로컬 검증 완료)

```bash
$ curl -sI http://localhost/ | grep -i content-type
Content-Type: text/html; charset=utf-8     ✅

$ docker compose exec -T backend sh -c 'echo $LANG'
C.UTF-8                                     ✅

$ docker compose exec -T frontend sh -c 'echo $LANG'
C.UTF-8                                     ✅

$ ./scripts/smoke.sh
[smoke] All probes passed.                  ✅
```

## Acceptance Criteria

- [x] `curl -I` 응답 헤더에 `Content-Type: text/html; charset=utf-8` 포함
- [x] `backend` / `frontend` 컨테이너 `locale` 에 `LANG=C.UTF-8` 포함
- [x] `scripts/smoke.sh` 통과
- [ ] 브라우저 육안으로 한글 UI 정상 렌더링 (reviewer 확인 요망)
- [ ] CI: lint / test / e2e / security 초록불

## Test plan

- [ ] `docker compose up -d` 후 `http://localhost` 접속 → 대시보드 한글 라벨 정상 렌더 확인
- [ ] Playwright E2E (한글 placeholder · title assertion 포함) 통과
- [ ] `.github/workflows/lint.yml` / `test.yml` 통과

## Educational note

이 사건은 전형적인 **계층 간 계약(contract) 불일치** 예제입니다. HTML 메타 태그(애플리케이션 레이어)와 HTTP 헤더(전송 레이어)가 서로 다른 인코딩을 말하면 하위 계층(HTTP)이 이깁니다. *"각 레이어는 자기 계약에 책임을 진다"* — 이게 3-Tier 에서 인코딩을 반드시 **가장 바깥 게이트웨이(nginx)** 에서 강제해야 하는 이유입니다.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)